### PR TITLE
fix: 修复终端黑屏及 Node.js 兼容性问题

### DIFF
--- a/scripts/bin/claude
+++ b/scripts/bin/claude
@@ -4,6 +4,11 @@ set -eu
 NODE_BIN="${DEVHAVEN_NODE_BIN:-node}"
 WRAPPER_PATH="${DEVHAVEN_CLAUDE_WRAPPER_PATH:-}"
 
+# Ensure node supports ES2020 syntax (nullish coalescing); fall back to shell node if too old.
+if ! "$NODE_BIN" -e "null ?? 0" 2>/dev/null; then
+  NODE_BIN="node"
+fi
+
 if [ -z "$WRAPPER_PATH" ]; then
   echo "DEVHAVEN_CLAUDE_WRAPPER_PATH 未设置" >&2
   exit 1

--- a/scripts/bin/codex
+++ b/scripts/bin/codex
@@ -4,6 +4,11 @@ set -eu
 NODE_BIN="${DEVHAVEN_NODE_BIN:-node}"
 WRAPPER_PATH="${DEVHAVEN_CODEX_WRAPPER_PATH:-}"
 
+# Ensure node supports ES2020 syntax (nullish coalescing); fall back to shell node if too old.
+if ! "$NODE_BIN" -e "null ?? 0" 2>/dev/null; then
+  NODE_BIN="node"
+fi
+
 if [ -z "$WRAPPER_PATH" ]; then
   echo "DEVHAVEN_CODEX_WRAPPER_PATH 未设置" >&2
   exit 1

--- a/scripts/devhaven-claude-wrapper.mjs
+++ b/scripts/devhaven-claude-wrapper.mjs
@@ -66,7 +66,9 @@ function quoteForJsonCommand(value) {
 }
 
 export function buildClaudeHooksSettings(env = process.env) {
-  const nodeBin = normalizeOptional(env.DEVHAVEN_NODE_BIN) ?? process.execPath;
+  // Always use the current node (which passed the ES2020 check in the shell wrapper)
+  // rather than DEVHAVEN_NODE_BIN which may point to an incompatible old version.
+  const nodeBin = process.execPath;
   const hookPath = normalizeOptional(env.DEVHAVEN_CLAUDE_HOOK_PATH);
   if (!hookPath) {
     return null;

--- a/scripts/devhaven-codex-wrapper.mjs
+++ b/scripts/devhaven-codex-wrapper.mjs
@@ -61,7 +61,7 @@ export function buildWrappedCodexSpawn(argv = process.argv.slice(2), env = proce
   });
 
   const hookPath = normalizeOptional(env.DEVHAVEN_CODEX_HOOK_PATH);
-  const nodeBin = normalizeOptional(env.DEVHAVEN_NODE_BIN) ?? process.execPath;
+  const nodeBin = process.execPath;
   if (!hasNotifyOverride && hookPath && nodeBin) {
     args.unshift(
       "-c",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -19,7 +19,7 @@ crate-type = ["staticlib", "cdylib", "rlib"]
 tauri-build = { version = "2", features = [] }
 
 [dependencies]
-tauri = { version = "2", features = ["macos-private-api"] }
+tauri = { version = "2", features = ["macos-private-api", "devtools"] }
 tauri-plugin-dialog = "2"
 tauri-plugin-opener = "2"
 tauri-plugin-clipboard-manager = "2"

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -5,7 +5,7 @@
   "identifier": "com.devhaven",
   "build": {
     "beforeDevCommand": "npm run dev",
-    "devUrl": "http://localhost:1410",
+    "devUrl": "http://localhost:1420",
     "beforeBuildCommand": "npm run build",
     "frontendDist": "../dist"
   },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,4 +1,5 @@
 import { Suspense, lazy, useCallback, useEffect, useMemo } from "react";
+import TerminalErrorBoundary from "./components/TerminalErrorBoundary";
 import Sidebar from "./components/Sidebar";
 import MainContent from "./components/MainContent";
 import DetailPanel from "./components/DetailPanel";
@@ -496,31 +497,33 @@ function AppLayout() {
             terminal.showTerminalWorkspace ? "opacity-100" : "opacity-0 pointer-events-none"
           }`}
         >
-          <Suspense fallback={<div className="h-full w-full bg-[var(--bg)]" />}>
-            <TerminalWorkspaceWindow
-              openProjects={terminal.terminalOpenProjects}
-              activeProjectId={terminal.terminalActiveProjectId}
-              quickCommandDispatch={terminal.terminalQuickCommandDispatch}
-              onSelectProject={terminal.selectTerminalProject}
-              onCloseProject={terminal.handleCloseTerminalProject}
-              onCreateWorktree={handleTerminalCreateWorktree}
-              onOpenWorktree={handleTerminalOpenWorktree}
-              onDeleteWorktree={handleTerminalDeleteWorktree}
-              onRetryWorktree={handleTerminalRetryWorktree}
-              onRefreshWorktrees={handleTerminalRefreshWorktrees}
-              onRegisterPersistWorkspace={terminal.registerTerminalWorkspacePersistence}
-              onAddProjectScript={addProjectScript}
-              onUpdateProjectScript={updateProjectScript}
-              onRemoveProjectScript={removeProjectScript}
-              onExit={handleTerminalExit}
-              windowLabel={MAIN_WINDOW_LABEL}
-              isVisible={terminal.showTerminalWorkspace}
-              terminalTheme={appState.settings.terminalTheme}
-              sharedScriptsRoot={appState.settings.sharedScriptsRoot}
-              terminalUseWebglRenderer={appState.settings.terminalUseWebglRenderer}
-              gitWorktreesByProjectId={terminal.terminalGitWorktreesByProjectId}
-            />
-          </Suspense>
+          <TerminalErrorBoundary onReset={handleTerminalExit}>
+            <Suspense fallback={<div className="h-full w-full bg-[#171717]" />}>
+              <TerminalWorkspaceWindow
+                openProjects={terminal.terminalOpenProjects}
+                activeProjectId={terminal.terminalActiveProjectId}
+                quickCommandDispatch={terminal.terminalQuickCommandDispatch}
+                onSelectProject={terminal.selectTerminalProject}
+                onCloseProject={terminal.handleCloseTerminalProject}
+                onCreateWorktree={handleTerminalCreateWorktree}
+                onOpenWorktree={handleTerminalOpenWorktree}
+                onDeleteWorktree={handleTerminalDeleteWorktree}
+                onRetryWorktree={handleTerminalRetryWorktree}
+                onRefreshWorktrees={handleTerminalRefreshWorktrees}
+                onRegisterPersistWorkspace={terminal.registerTerminalWorkspacePersistence}
+                onAddProjectScript={addProjectScript}
+                onUpdateProjectScript={updateProjectScript}
+                onRemoveProjectScript={removeProjectScript}
+                onExit={handleTerminalExit}
+                windowLabel={MAIN_WINDOW_LABEL}
+                isVisible={terminal.showTerminalWorkspace}
+                terminalTheme={appState.settings.terminalTheme}
+                sharedScriptsRoot={appState.settings.sharedScriptsRoot}
+                terminalUseWebglRenderer={appState.settings.terminalUseWebglRenderer}
+                gitWorktreesByProjectId={terminal.terminalGitWorktreesByProjectId}
+              />
+            </Suspense>
+          </TerminalErrorBoundary>
         </div>
       ) : null}
     </div>

--- a/src/components/TerminalErrorBoundary.tsx
+++ b/src/components/TerminalErrorBoundary.tsx
@@ -1,0 +1,52 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+
+type Props = {
+  children: ReactNode;
+  onReset?: () => void;
+};
+
+type State = {
+  error: Error | null;
+};
+
+class TerminalErrorBoundary extends Component<Props, State> {
+  state: State = { error: null };
+
+  static getDerivedStateFromError(error: Error): State {
+    return { error };
+  }
+
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("终端工作区渲染失败", error, info.componentStack);
+  }
+
+  handleReset = () => {
+    this.setState({ error: null });
+    this.props.onReset?.();
+  };
+
+  render() {
+    if (!this.state.error) {
+      return this.props.children;
+    }
+
+    return (
+      <div className="flex h-full flex-col items-center justify-center gap-4 bg-[#171717] p-8 text-white">
+        <div className="text-lg font-semibold text-red-400">终端工作区加载失败</div>
+        <pre className="max-h-[300px] max-w-[600px] overflow-auto rounded-lg bg-[#0d0d0d] p-4 text-[13px] text-red-300">
+          {this.state.error.message}
+          {this.state.error.stack ? `\n\n${this.state.error.stack}` : ""}
+        </pre>
+        <button
+          type="button"
+          className="rounded-md border border-[rgba(255,255,255,0.15)] px-4 py-2 text-[13px] font-semibold text-white transition-colors hover:bg-[rgba(255,255,255,0.1)]"
+          onClick={this.handleReset}
+        >
+          返回主界面
+        </button>
+      </div>
+    );
+  }
+}
+
+export default TerminalErrorBoundary;

--- a/src/components/terminal/TerminalPane.tsx
+++ b/src/components/terminal/TerminalPane.tsx
@@ -34,7 +34,7 @@ const SEARCH_OPTIONS = {
   wholeWord: false,
 };
 const SAFE_LINK_PROTOCOLS = new Set(["http:", "https:", "mailto:"]);
-const LOCAL_PATH_TOKEN_REGEX = /(?<![:/A-Za-z0-9._~-])(?:~\/|\/|Users\/)[^\s"'<>`|]+/g;
+const LOCAL_PATH_TOKEN_REGEX = /(^|[^:/A-Za-z0-9._~-])(?:~\/|\/|Users\/)[^\s"'<>`|]+/g;
 const LOCAL_PATH_TRAILING_PUNCTUATION = /[.,;!?]+$/;
 const LOCAL_PATH_MATCH_WINDOW_MAX_CHARS = 2048;
 
@@ -236,12 +236,14 @@ function createLocalPathLinkProvider(
       LOCAL_PATH_TOKEN_REGEX.lastIndex = 0;
       let match: RegExpExecArray | null = null;
       while ((match = LOCAL_PATH_TOKEN_REGEX.exec(mergedText)) !== null) {
-        const parsedPath = parseLocalPathToken(match[0], homeDir);
+        const prefixLen = match[1].length;
+        const pathText = match[0].slice(prefixLen);
+        const parsedPath = parseLocalPathToken(pathText, homeDir);
         if (!parsedPath) {
           continue;
         }
 
-        const [startLine, startColumn] = mapStringIndexToBufferPosition(term, startLineNumber, 0, match.index);
+        const [startLine, startColumn] = mapStringIndexToBufferPosition(term, startLineNumber, 0, match.index + prefixLen);
         const [endLine, endColumn] = mapStringIndexToBufferPosition(
           term,
           startLine,


### PR DESCRIPTION
- fix(terminal): 正则后行断言 (?<!...) 不兼容 WKWebView 导致终端模块加载失败黑屏
- fix(wrapper): shell wrapper 检测 DEVHAVEN_NODE_BIN 版本，旧版自动回退到 shell node
- fix(hooks): hook 命令使用 process.execPath 而非 DEVHAVEN_NODE_BIN，避免用旧版 node 执行
- fix(config): devUrl 端口从 1410 修正为 1420，与 Vite 配置一致
- feat(debug): 添加 TerminalErrorBoundary 和 devtools 特性，便于排查终端渲染错误