### PR TITLE
fix: normalize clicked local paths in Ghostty

### DIFF
--- a/macos/Sources/DevHavenApp/Ghostty/GhosttySurfaceBridge.swift
+++ b/macos/Sources/DevHavenApp/Ghostty/GhosttySurfaceBridge.swift
@@ -290,12 +290,90 @@ final class GhosttySurfaceBridge {
             return false
         }
         let data = Data(bytes: pointer, count: length)
-        guard let string = String(data: data, encoding: .utf8), !string.isEmpty else {
+        guard let string = String(data: data, encoding: .utf8),
+              let url = Self.resolvedOpenURL(from: string, workingDirectory: state.pwd)
+        else {
             return false
         }
 
-        let url = URL(string: string) ?? URL(fileURLWithPath: string)
-        NSWorkspace.shared.open(url)
-        return true
+        return NSWorkspace.shared.open(url)
+    }
+
+    static func resolvedOpenURL(from rawString: String, workingDirectory: String?) -> URL? {
+        let trimmed = rawString.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmed.isEmpty else {
+            return nil
+        }
+
+        if let assignmentValue = shellAssignmentValue(in: trimmed) {
+            return resolvedOpenURL(from: assignmentValue, workingDirectory: workingDirectory)
+        }
+
+        if let url = URL(string: trimmed), let scheme = url.scheme, !scheme.isEmpty {
+            return url
+        }
+
+        if let fileURL = resolvedFileURL(from: trimmed, workingDirectory: workingDirectory) {
+            return fileURL
+        }
+
+        return URL(string: trimmed)
+    }
+
+    private static func shellAssignmentValue(in string: String) -> String? {
+        guard let separatorIndex = string.firstIndex(of: "=") else {
+            return nil
+        }
+
+        let key = String(string[..<separatorIndex])
+        guard isShellVariableName(key) else {
+            return nil
+        }
+
+        let valueStart = string.index(after: separatorIndex)
+        let value = String(string[valueStart...])
+        guard isPathLike(value) else {
+            return nil
+        }
+        return value
+    }
+
+    private static func resolvedFileURL(from string: String, workingDirectory: String?) -> URL? {
+        if string == "~" || string.hasPrefix("~/") {
+            return URL(fileURLWithPath: (string as NSString).expandingTildeInPath)
+        }
+
+        if string.hasPrefix("/") {
+            return URL(fileURLWithPath: string)
+        }
+
+        guard let workingDirectory, isRelativePath(string) else {
+            return nil
+        }
+
+        return URL(fileURLWithPath: string, relativeTo: URL(fileURLWithPath: workingDirectory, isDirectory: true))
+            .standardizedFileURL
+    }
+
+    private static func isShellVariableName(_ string: String) -> Bool {
+        guard let first = string.first, first == "_" || first.isLetter else {
+            return false
+        }
+        return string.dropFirst().allSatisfy { $0 == "_" || $0.isLetter || $0.isNumber }
+    }
+
+    private static func isPathLike(_ string: String) -> Bool {
+        string.hasPrefix("/")
+            || string == "~"
+            || string.hasPrefix("~/")
+            || isRelativePath(string)
+            || string.hasPrefix("file://")
+    }
+
+    private static func isRelativePath(_ string: String) -> Bool {
+        string == "."
+            || string == ".."
+            || string.hasPrefix("./")
+            || string.hasPrefix("../")
     }
 }

--- a/macos/Tests/DevHavenAppTests/GhosttySurfaceBridgeOpenURLTests.swift
+++ b/macos/Tests/DevHavenAppTests/GhosttySurfaceBridgeOpenURLTests.swift
@@ -1,0 +1,44 @@
+import XCTest
+@testable import DevHavenApp
+
+final class GhosttySurfaceBridgeOpenURLTests: XCTestCase {
+    func testResolvedOpenURLPreservesHTTPURL() {
+        let url = GhosttySurfaceBridge.resolvedOpenURL(
+            from: "https://github.com/zxcvbnmzsedr/devhaven/issues/42",
+            workingDirectory: nil
+        )
+
+        XCTAssertEqual(url?.absoluteString, "https://github.com/zxcvbnmzsedr/devhaven/issues/42")
+        XCTAssertFalse(url?.isFileURL ?? true)
+    }
+
+    func testResolvedOpenURLTreatsAbsolutePathAsFileURL() {
+        let path = "/Users/zhaotianzeng/WebstormProjects/DevHaven/macos/.build/native-app/release/DevHaven.app"
+
+        let url = GhosttySurfaceBridge.resolvedOpenURL(from: path, workingDirectory: nil)
+
+        XCTAssertEqual(url?.path, path)
+        XCTAssertTrue(url?.isFileURL ?? false)
+    }
+
+    func testResolvedOpenURLExtractsAbsolutePathFromShellAssignment() {
+        let path = "/Users/zhaotianzeng/WebstormProjects/DevHaven/macos/.build/native-app/release"
+
+        let url = GhosttySurfaceBridge.resolvedOpenURL(from: "OUTPUT_DIR=\(path)", workingDirectory: nil)
+
+        XCTAssertEqual(url?.path, path)
+        XCTAssertTrue(url?.isFileURL ?? false)
+    }
+
+    func testResolvedOpenURLResolvesRelativePathAgainstWorkingDirectory() {
+        let workingDirectory = "/Users/zhaotianzeng/WebstormProjects/DevHaven/macos"
+
+        let url = GhosttySurfaceBridge.resolvedOpenURL(
+            from: "./.build/native-app/release",
+            workingDirectory: workingDirectory
+        )
+
+        XCTAssertEqual(url?.path, workingDirectory + "/.build/native-app/release")
+        XCTAssertTrue(url?.isFileURL ?? false)
+    }
+}

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1842,189 +1842,69 @@
   - `git ls-remote origin refs/tags/v3.1.0^{} | cut -f1 | cut -c1-12` → `c3707f2b68ad`
   - `git rev-parse --short=12 HEAD` → `c3707f2b68ad`
 
-## 2026-03-24 Command+W 关闭整个 App 语义修复
 
-- [x] 梳理 DevHaven 当前 Command+W / 主窗口关闭链路，确认直接原因与设计层诱因
-- [x] 对比 cmux、Ghostty、Supacode 的关闭语义与提醒策略，确定 DevHaven 的目标行为
-- [x] 先补能约束目标语义的测试，再实现最小修复
-- [x] 运行定向验证并在本文件追加 Review（含根因、方案、长期建议与证据）
+## 2026-03-24 Issue #42 链接点击报错（应用程序无法打开 -50）
 
-## Review（2026-03-24 Command+W 关闭整个 App 语义修复）
+- [x] 收集 issue 现场信息、截图/日志与相关历史上下文
+- [x] 定位 DevHaven 中链接识别与点击打开链路
+- [x] 复现并确认 `-50` 的直接触发条件
+- [x] 如需修复，补最小验证并实施修复
+- [x] 回填 Review，记录直接原因、设计层诱因、修复方案与验证证据
+
+## Review（2026-03-24 Issue #42 链接点击报错）
 
 - 结果：
-  1. DevHaven 现在会在主窗口收到 `⌘W` 时先弹提醒，明确告知“这会关闭整个 DevHaven 主窗口”，避免把它误当成“关闭当前 pane/tab”。
-  2. 关闭最后一个窗口后，App 不会再直接按“彻底退出”语义处理；重新激活应用或点击 dock 图标时，会尝试恢复主窗口。
-- 对标结论：
-  1. `cmux` 把 `⌘W` 定义成 **Close Tab / Close Surface**，真正关闭窗口走独立语义，并在 `AppDelegate.closeWindowWithConfirmation(...)` 上做确认。
-  2. `Ghostty` 保留 **Close Window** 语义，但 `TerminalController.closeWindow(...)` / `windowShouldClose(...)` 会在仍有运行中终端时弹确认。
-  3. `Supacode` 把 `⌘W` 接到 **closeFocusedSurface**，同时 `applicationShouldTerminateAfterLastWindowClosed == false`，并在 app reactivate / reopen 时恢复主窗口。
-  4. DevHaven 当前还是单主窗口模型，所以本轮没有直接改成“关闭 pane/tab”，而是先补最小且清晰的保护：**提醒 + last-window reopen**。
+  1. 已修复 DevHaven 内嵌 Ghostty 点击本地路径时误报“应用程序无法打开 -50”的问题。
+  2. 现在 `https://...` 仍按普通 URL 打开，`/Users/...`、`OUTPUT_DIR=/Users/...`、`./relative/path` 会先被解析成正确的 file URL 再交给 `NSWorkspace`。
 - 直接原因：
-  1. DevHaven 当前只显式收口了 `⌘N`（禁用默认 New Window），但没有收口 `⌘W`；在 `WindowGroup` 下它直接落回系统默认“关闭窗口”语义。
-  2. `DevHavenApp.swift` 之前没有 `NSApplicationDelegateAdaptor` 去覆盖 `applicationShouldTerminateAfterLastWindowClosed`，也没有 app 重新激活时的主窗口恢复逻辑，所以用户会感知成“整个 App 被关掉了”。
+  1. `GhosttySurfaceBridge.openURL(...)` 原先直接对点击文本执行 `URL(string: string) ?? URL(fileURLWithPath: string)`。
+  2. 对 `/Users/...` 或 `APP_PATH=/Users/...` 这类**没有 scheme 的本地路径**，`URL(string:)` 会返回一个无 scheme 的相对 URL；`NSWorkspace.shared.open(...)` 随后稳定报 `NSOSStatusErrorDomain Code=-50`。
 - 设计层诱因：
-  1. 单主窗口产品模型只收口了一半：对“不能新开窗口”有明确策略，对“关闭唯一主窗口时该怎么提醒/恢复”没有同级策略。
-  2. 未发现明显系统设计缺陷；问题集中在 App 壳层缺少统一的主窗口生命周期约束。
+  1. URL 链接与文件路径共用同一条“先 `URL(string:)` 再兜底”的解析逻辑，但这两个输入域的判定规则并不相同。
+  2. `build-native-app.sh` 输出的 `APP_PATH=...` / `OUTPUT_DIR=...` 进一步放大了这个问题：终端点击拿到的并不一定是纯路径，而可能是 shell assignment 形式的 token。
+  3. 未发现明显系统设计缺陷，但存在边界处理收口不足：点击打开链路缺少对“无 scheme 本地路径”和“shell assignment 包裹路径”的显式归一化。
 - 当前修复方案：
-  1. 在 `DevHavenApp.swift` 增加 `DevHavenAppDelegate + MainWindowRestorer`，把“最后一个窗口关闭后的应用行为”收口到 App 壳；
-  2. 在 `AppRootView.swift` 增加 `MainWindowCloseShortcutBridge`，通过本地 keyDown monitor 仅拦截主窗口 `⌘W`，先弹提醒，再决定是否 `performClose`；
-  3. 新增纯逻辑测试，约束“主窗口恢复”和“关闭快捷键提醒”两个行为。
+  1. 在 `GhosttySurfaceBridge` 中新增 `resolvedOpenURL(from:workingDirectory:)`，先区分显式 scheme URL、本地绝对路径、`~/...`、相对路径以及 `KEY=/path` 形式的 shell assignment；
+  2. `openURL(...)` 改为先归一化目标，再调用 `NSWorkspace.shared.open(...)`；
+  3. 新增 `GhosttySurfaceBridgeOpenURLTests`，覆盖 HTTP URL、绝对路径、shell assignment 与相对路径四类输入。
 - 长期改进建议：
-  1. 如果后续要进一步对齐 `cmux / Supacode`，更理想的终局是把 `⌘W` 迁移成 **关闭当前工作区 / 当前 terminal surface**，把“关闭整个主窗口”改成单独快捷键与菜单语义。
-  2. 后续若主窗口出现更多 auxiliary window / panel，最好把当前主窗口 close policy 抽成单独 window lifecycle 模块，而不是继续堆在 AppRootView 里。
+  1. 若后续还要暴露更多“可点击产物路径”，可以考虑把脚本输出从 `KEY=/path` 统一升级为更明确的人类文案或 `file://` 形式，减少终端侧解析歧义；
+  2. 若 Ghostty 后续还会上报更多可点击 token 类型，可把这套解析逻辑继续下沉成独立的 link resolver，避免桥接层不断堆判断分支。
 - 验证证据：
-  - RED：`swift test --package-path macos --filter InitialWindowActivatorTests` 初次运行失败，报错 `cannot find 'MainWindowRestorer' in scope` / `cannot find 'MainWindowCloseShortcutHandler' in scope`，证明新增测试先于实现落地
-  - 绿灯：`swift test --package-path macos --filter 'InitialWindowActivatorTests|MainWindowRestorerTests|MainWindowCloseShortcutHandlerTests'` → 7 tests，0 failures
-  - 回归：`swift test --package-path macos --filter 'InitialWindowActivatorTests|MainWindowRestorerTests|MainWindowCloseShortcutHandlerTests|ProjectDetailPanelCloseActionTests'` → 8 tests，0 failures
-  - 补充回归：`swift test --package-path macos --filter 'DevHavenAppCommandTests|ProjectDetailPanelCloseActionTests'` → 4 tests，0 failures
-  - 编译：`swift build --package-path macos` → `Build complete! (2.15s)`
-  - 参考源码证据：
-    - `cmux/Sources/cmuxApp.swift:626-646`、`cmux/Sources/AppDelegate.swift:4750-4787`
-    - `supacode/supacode/App/supacodeApp.swift:31-71`、`supacode/supacode/Commands/TerminalCommands.swift:15-35`
-    - `ghostty/macos/Sources/Features/Terminal/TerminalController.swift:1285-1307`
+  - 现场 issue：`gh api repos/zxcvbnmzsedr/devhaven/issues/42` → issue 标题为“链接点击报错。显示应用程序无法打开。”，截图与用户粘贴日志对应 `APP_PATH=` / `OUTPUT_DIR=` 点击场景
+  - 独立复现：`swift -e 'import AppKit ... NSWorkspace.shared.open(URL(string: "APP_PATH=/Users/..." )!, configuration: .init()) ...'` → `NSUnderlyingError=NSOSStatusErrorDomain Code=-50`
+  - RED：`swift test --package-path macos --filter GhosttySurfaceBridgeOpenURLTests` → 编译失败，提示 `GhosttySurfaceBridge` 尚无 `resolvedOpenURL`
+  - GREEN：`swift test --package-path macos --filter GhosttySurfaceBridgeOpenURLTests` → 4 tests，0 failures
+  - 相关回归：`swift test --package-path macos --filter 'GhosttySurfaceBridgeOpenURLTests|GhosttySurfaceBridgeTabPaneTests|GhosttySurfaceCallbackContextTests'` → 11 tests，0 failures
+  - 构建验证：`swift build --package-path macos` → `Build complete! (0.58s)`
 
-## 2026-03-24 Command+W 取消后界面被隐藏修复
 
-- [x] 复盘当前取消后界面被隐藏的链路，确认直接原因与设计层诱因
-- [x] 把提醒挂点从原始 keyDown 监控迁移到真实 window close 生命周期，并先补失败测试
-- [x] 运行定向验证并同步更新 Review / lessons
+## 2026-03-24 Issue #42 修复提交与 PR
 
-## Review（2026-03-24 Command+W 取消后界面被隐藏修复）
+- [x] 基于最新改动做一轮提交前新鲜验证
+- [x] 创建独立分支并仅暂存本轮修复相关文件
+- [x] 提交修复并推送远端分支
+- [x] 创建 Pull Request 并记录链接与验证证据
+
+## Review（2026-03-24 Issue #42 修复提交与 PR）
 
 - 结果：
-  1. DevHaven 已移除原来的 `keyDown` 本地监控拦截方案，主窗口关闭提醒现在挂到真实 `windowShouldClose` 生命周期上。
-  2. 取消关闭时，窗口会明确停留在当前可见状态，不再出现“点了取消但界面被隐藏”的半关闭状态。
+  1. 已在分支 `fix/issue-42-ghostty-open-url` 提交并推送本轮修复。
+  2. 已创建 Pull Request：`https://github.com/zxcvbnmzsedr/devhaven/pull/43`。
 - 直接原因：
-  1. 上一版把提醒挂在 `MainWindowCloseShortcutBridge` 的本地 `keyDown` monitor 上，属于**在窗口关闭流程之外半路拦截快捷键**。
-  2. 这种拦截方式没有参与 `NSWindow` 的真实 close contract；因此取消时虽然没有显式 `performClose()`，但窗口仍可能已经进入部分 close/visibility 变化流程，最终表现成“取消后界面被隐藏”。
+  1. 用户确认本地手动验证已通过，下一步需求是把已验证修复整理成可审阅的远端 PR。
 - 设计层诱因：
-  1. 关闭提醒放错层级：这类语义本质上属于 window lifecycle，而不是 keyboard event lifecycle。
-  2. 未发现明显系统设计缺陷；问题集中在 App 壳层把“快捷键拦截”误当成了“窗口关闭语义”的真挂点。
-- 当前修复方案：
-  1. 用 `MainWindowCloseConfirmationBridge` 接管主窗口 delegate；
-  2. 将提醒逻辑收口到 `MainWindowCloseConfirmationHandler.shouldAllowClose(windowNumber:)`；
-  3. 由 `windowShouldClose(_:)` 决定是否允许关闭，而不是在原始按键事件上先弹框。
-- 长期改进建议：
-  1. 如果后续真的把 `⌘W` 语义改成“关闭当前 workspace / pane”，也仍应让“关闭整个主窗口”的风险确认继续挂在 `windowShouldClose` 或等价的 close lifecycle 上，而不是再回到 raw event monitor。
-  2. 若后续主窗口需要更多 delegate 行为，建议把当前桥接继续演进成独立 window lifecycle coordinator，避免在 AppRootView 堆积更多窗口职责。
-- 验证证据：
-  - RED：`swift test --package-path macos --filter 'MainWindowCloseConfirmationHandlerTests'` 初次运行失败，报错 `cannot find 'MainWindowCloseConfirmationHandler' in scope` / `cannot find type 'MainWindowClosePrompting' in scope`，证明本轮先写了新生命周期测试，再补实现
-  - 绿灯：`swift test --package-path macos --filter 'MainWindowCloseConfirmationHandlerTests|InitialWindowActivatorTests|MainWindowRestorerTests|ProjectDetailPanelCloseActionTests'` → 8 tests，0 failures
-  - 补充回归：`swift test --package-path macos --filter 'DevHavenAppCommandTests|ProjectDetailPanelCloseActionTests'` → 4 tests，0 failures
-  - 编译：`swift build --package-path macos` → `Build complete! (1.92s)`
-
-## 2026-03-24 Command+W 层级关闭语义修正
-
-- [x] 根据用户确认的目标语义梳理正确层级：浮层 -> pane -> tab -> 退出 workspace -> 主页关窗
-- [x] 先补失败测试，约束 close planner 的层级决策顺序
-- [x] 将 `⌘W` 快捷键处理改为内部层级关闭；主页态继续走主窗口确认
-- [x] 运行定向验证并同步 Review / lessons / AGENTS
-
-## Review（2026-03-24 Command+W 层级关闭语义修正）
-
-- 结果：
-  1. `⌘W` 现在不再优先尝试关闭主窗口，而是按**浮层 -> pane -> tab -> 退出 workspace -> 主页关窗**的顺序逐级收口。
-  2. 上一轮新增的主窗口关闭确认逻辑现在降为**主页态 fallback**：只有已经没有浮层、也不在 workspace 中时，`⌘W` 才会继续触发主窗口关闭确认。
-- 直接原因：
-  1. 之前的实现把 `⌘W` 的主语义仍然放在“关主窗口”，只是额外加了提醒；这和 DevHaven 的单主窗口 + 内部 workspace/pane 模型不一致。
-  2. `WorkspaceTopologyModels.closePane(...)` / `closeTab(...)` 与 `NativeAppViewModel.exitWorkspace()` 明明已经能表达内部层级关闭，但 App 壳没有先消费这些能力。
-- 设计层诱因：
-  1. 关闭动作的抽象层级放错了：把 window close 当成第一入口，而不是把它当成“内部层级都耗尽后的最后 fallback”。
-  2. 未发现明显系统设计缺陷；这次主要是产品语义与 App 壳路由顺序不匹配。
-- 当前修复方案：
-  1. 在 `AppRootView.swift` 增加 `MainWindowCloseShortcutPlanner`，显式产出 `hideSettings / hideDashboard / hideRecycleBin / hideDetailPanel / closePane / closeTab / exitWorkspace / closeWindow` 八种动作；
-  2. 新增 `MainWindowCloseShortcutBridge` 本地消费 `⌘W`，只有在 planner 判定为内部动作时才吞掉事件；
-  3. 当 planner 返回 `.closeWindow` 时，放行事件给已有 `windowShouldClose` 确认链路。
-- 长期改进建议：
-  1. 后续若要覆盖菜单点击“关闭窗口”或红点关闭，也可以复用同一份 close planner，把整套关闭语义统一到一个 coordinator，而不是只覆盖快捷键路径。
-  2. 对 workspace 内更多局部浮层（如 project picker / worktree 对话框），后续也应接到同一 planner 层级，而不是散落成各自的局部快捷键处理。
-- 验证证据：
-  - RED：`swift test --package-path macos --filter 'MainWindowCloseShortcutPlannerTests'` 初次运行失败，报错 `cannot find 'MainWindowCloseShortcutPlanner' in scope` / `cannot find 'MainWindowCloseShortcutContext' in scope`，证明本轮先补了层级关闭测试
-  - 绿灯：`swift test --package-path macos --filter 'MainWindowCloseShortcutPlannerTests'` → 5 tests，0 failures
-  - 回归：`swift test --package-path macos --filter 'MainWindowCloseShortcutPlannerTests|MainWindowCloseConfirmationHandlerTests|MainWindowRestorerTests|InitialWindowActivatorTests|ProjectDetailPanelCloseActionTests|DevHavenAppCommandTests'` → 16 tests，0 failures
-  - 编译：`swift build --package-path macos` → `Build complete! (1.96s)`
-
-## 2026-03-24 Command+W 主页关窗提示文案精简
-
-- [x] 先补文案测试，约束主页态关窗提示使用更简洁的标题与说明
-- [x] 以最小改动收短提示文案，不改按钮语义
-- [x] 运行定向验证并在本文件追加 Review
-
-## Review（2026-03-24 Command+W 主页关窗提示文案精简）
-
-- 结果：
-  1. 主页态主窗口关闭提示已收短，不再解释“主页/当前状态/整个窗口”等上下文。
-  2. 当前文案改为：标题 `关闭 DevHaven？`，说明 `这会关闭主窗口。`，按钮仍是 `关闭窗口 / 取消`。
-- 直接原因：
-  1. 上一版提示虽然语义完整，但文案过长，用户感知上像“解释系统行为”，不够利落。
-- 设计层诱因：
-  1. 未发现明显系统设计缺陷；这是交互文案粒度问题，不是关闭语义链路问题。
-- 当前修复方案：
-  1. 给 `AppKitMainWindowClosePrompt` 抽出 `copy` 真相源；
-  2. 维持原有按钮语义，仅把标题和说明文案改成更短版本；
-  3. 用运行时 copy 测试约束后续不要再把文案改回冗长解释。
-- 长期改进建议：
-  1. 如果后续主页态还要区分“主窗口关闭”和“应用退出”，优先保持短句 + 明确动词，不要再次堆长解释。
-- 验证证据：
-  - RED：`swift test --package-path macos --filter 'MainWindowClosePromptCopyTests'` 初次运行失败，报错 `type 'AppKitMainWindowClosePrompt' has no member 'copy'`
-  - 回归：`swift test --package-path macos --filter 'MainWindowClosePromptCopyTests|MainWindowCloseShortcutPlannerTests|MainWindowCloseConfirmationHandlerTests|MainWindowRestorerTests|InitialWindowActivatorTests|ProjectDetailPanelCloseActionTests|DevHavenAppCommandTests'` → 17 tests，0 failures
-  - 编译：`swift build --package-path macos` → `Build complete! (2.01s)`
-
-## 2026-03-24 Command+Q 双击退出增强
-
-- [x] 先补 `⌘Q` 双击退出状态机/文案测试，约束第一次只提示、第二次才退出
-- [x] 实现 App 级 quit guard、toast 轻提示与 `.appTermination` 命令接管
-- [x] 运行定向验证并同步更新 Review / lessons / AGENTS
-
-## Review（2026-03-24 Command+Q 双击退出增强）
-
-- 结果：
-  1. `⌘Q` / 菜单“退出 DevHaven”现在都会先进入 App 级 quit guard：第一次仅显示 toast `再按一次 ⌘Q 退出 DevHaven`，1.5 秒内第二次才真正退出。
-  2. 如果当前没有可见窗口，则不会做无意义的第一次提示，而是直接退出。
-- 直接原因：
-  1. 当前仓库原本没有接管 `.appTermination`，所以 `⌘Q` 一直是系统默认立即 terminate，无法表达“第一次提示、第二次确认”的交互。
-- 设计层诱因：
-  1. 未发现明显系统设计缺陷；这是缺少独立 App 级退出状态机的问题，而不是 `⌘W` 层级关闭链的问题。
-- 当前修复方案：
-  1. 新增 `AppQuitGuard.swift`，把退出文案、纯状态机、运行时 guard 与 toast 视图集中收口；
-  2. 在 `DevHavenApp.swift` 用 `CommandGroup(replacing: .appTermination)` 接管 `⌘Q` 与菜单退出；
-  3. 在 `AppRootView.swift` 顶层叠加 toast 轻提示展示；
-  4. 保持现有 `⌘W` 语义不变，不把 quit guard 混进 window close 链。
-- 长期改进建议：
-  1. 如果后续要覆盖 Dock 菜单 Quit、系统 terminate 请求等更底层入口，可以继续把 `applicationShouldTerminate(_:)` 接入同一份 quit guard，而不是再复制一套确认逻辑。
-  2. toast 文案、时长与是否对“无可见窗口”直接退出，都建议继续由 `AppQuitGuard` 保持单一真相源，不要把这些常量散落回 AppRootView 或命令层。
-- 验证证据：
-  - RED：`swift test --package-path macos --filter 'AppQuitGuardStateMachineTests|AppQuitGuardCopyTests'` 初次运行失败，报错 `cannot find 'AppQuitGuardState' in scope` / `cannot find 'AppQuitGuardStateMachine' in scope`
-  - 绿灯：`swift test --package-path macos --filter 'AppQuitGuardStateMachineTests|AppQuitGuardCopyTests|MainWindowClosePromptCopyTests|MainWindowCloseShortcutPlannerTests|MainWindowCloseConfirmationHandlerTests|MainWindowRestorerTests|InitialWindowActivatorTests|ProjectDetailPanelCloseActionTests|DevHavenAppCommandTests'` → 23 tests，0 failures
-  - 编译：`swift build --package-path macos` → `Build complete! (0.15s)`
-
-## 2026-03-24 issue #36 关联 PR 提交
-
-- [x] 核对 issue #36 内容与当前本地改动范围是否匹配
-- [x] 跑提交前完整验证，确认当前工作区可用于发 PR
-- [x] 创建关联 issue #36 的分支与提交
-- [x] 推送分支并创建 PR
-- [x] 在本文件追加 Review（含 branch / commit / PR / 验证证据）
-
-## Review（2026-03-24 issue #36 关联 PR 提交）
-
-- 结果：
-  1. 已基于当前修复创建并推送分支 `fix/issue-36-close-semantics`。
-  2. 已提交 commit `9e0e378`（`fix: tighten main-window close behavior`）。
-  3. 已创建 PR `#41`：`https://github.com/zxcvbnmzsedr/devhaven/pull/41`。
-  4. PR 正文已使用 `Closes #36`，合并后会自动关闭 issue #36。
-- 直接原因：
-  1. issue #36 的标题就是 `command+w 导致整个窗口退出`，与当前本地修复范围直接匹配。
-- 设计层诱因：
-  1. 未发现新的系统设计缺陷；本轮主要是把已完成修复按 issue 语义收口为独立分支、提交与 PR。
+  1. 未发现明显系统设计缺陷；本轮只是标准的提交 / 推分支 / 建 PR 收口动作。
 - 当前处理方案：
-  1. 从 `main` 切出 `fix/issue-36-close-semantics`；
-  2. 提交核心修复为 `9e0e378 fix: tighten main-window close behavior`；
-  3. 推送分支并创建带 `Closes #36` 的 PR #41。
-- 长期改进建议：
-  1. 后续如果 issue 粒度继续细化，建议在开发开始时就直接从 `main` 切 issue 专属分支，避免像本次这样在 `main` 脏工作区里再收口。
+  1. 在 `main` 当前工作区上切出 `fix/issue-42-ghostty-open-url` 独立分支；
+  2. 仅暂存 `GhosttySurfaceBridge.swift`、新增测试与 `tasks/todo.md`，不混入 `.iflow/`、`.opencli/` 等本地未跟踪内容；
+  3. 提交 `fix(ghostty): normalize clicked local paths before open`；
+  4. 推送远端分支并创建 PR，PR 标题为 `fix: normalize clicked local paths in Ghostty`。
 - 验证证据：
-  - `swift test --package-path macos` → `Executed 300 tests, with 5 tests skipped and 0 failures`
-  - `swift build --package-path macos` → `Build complete! (1.14s)`
-  - `git push -u origin fix/issue-36-close-semantics` → 远端已创建并跟踪该分支
-  - `gh pr create --base main --head fix/issue-36-close-semantics ...` → `https://github.com/zxcvbnmzsedr/devhaven/pull/41`
+  - 新鲜验证：`swift test --package-path macos --filter 'GhosttySurfaceBridgeOpenURLTests|GhosttySurfaceBridgeTabPaneTests|GhosttySurfaceCallbackContextTests'` → 11 tests，0 failures
+  - 新鲜构建：`swift build --package-path macos` → `Build complete! (2.39s)`
+  - 暂存范围：`git diff --cached --stat` → 仅包含 `GhosttySurfaceBridge.swift`、`GhosttySurfaceBridgeOpenURLTests.swift`、`tasks/todo.md`
+  - 提交结果：`git commit -m "fix(ghostty): normalize clicked local paths before open"` → 生成提交 `f3f0560`
+  - 推送结果：`git push -u origin fix/issue-42-ghostty-open-url` → 远端分支创建成功并建立 tracking
+  - PR：`gh pr create --base main --head fix/issue-42-ghostty-open-url ...` → 返回 `https://github.com/zxcvbnmzsedr/devhaven/pull/43`
+


### PR DESCRIPTION
## Summary
- normalize Ghostty click targets before passing them to `NSWorkspace`
- treat absolute paths, `~/...`, relative paths, and `KEY=/path` shell assignments as file URLs instead of scheme-less URLs
- add regression coverage for HTTP URLs, absolute paths, shell assignments, and relative paths

## Test Plan
- swift test --package-path macos --filter 'GhosttySurfaceBridgeOpenURLTests|GhosttySurfaceBridgeTabPaneTests|GhosttySurfaceCallbackContextTests'
- swift build --package-path macos

Closes #42
