### PR TITLE
修复 worktree 生命周期问题并扩大侧栏点击热区

### DIFF
--- a/macos/Sources/DevHavenApp/WorkspaceProjectListView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceProjectListView.swift
@@ -130,12 +130,55 @@ private struct ProjectGroupView: View {
 
     var body: some View {
         VStack(alignment: .leading, spacing: 6) {
-            Button {
-                onSelectProject(group.rootProject.path)
-            } label: {
-                projectCard
+            HStack(spacing: 6) {
+                Button {
+                    onSelectProject(group.rootProject.path)
+                } label: {
+                    projectMainContent
+                }
+                .buttonStyle(.plain)
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .contentShape(.rect(cornerRadius: 10))
+
+                HStack(spacing: 4) {
+                    groupStatusAccessory
+
+                    HStack(spacing: 4) {
+                        if !group.rootProject.isTransientWorkspaceProject {
+                            iconButton(systemName: "arrow.clockwise", help: "刷新 worktree") {
+                                onRefreshWorktrees(group.rootProject.path)
+                            }
+                            iconButton(systemName: "plus", help: "创建或添加 worktree") {
+                                onRequestCreateWorktree(group.rootProject.path)
+                            }
+                        }
+                        iconButton(systemName: "xmark", help: "关闭项目") {
+                            onCloseProject(group.rootProject.path)
+                        }
+                    }
+                    .allowsHitTesting(isHovering)
+                    .opacity(isHovering ? 1 : 0)
+                    .animation(.easeInOut(duration: 0.15), value: isHovering)
+                }
+                .padding(.trailing, 6)
+                .padding(.vertical, 6)
+                .background(
+                    LinearGradient(
+                        colors: [cardBg.opacity(0), cardBg, cardBg],
+                        startPoint: .leading,
+                        endPoint: .trailing
+                    )
+                )
             }
-            .buttonStyle(.plain)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(cardBg)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(group.isActive ? NativeTheme.accent.opacity(0.5) : NativeTheme.border.opacity(0.5), lineWidth: 1)
+            )
+            .clipShape(.rect(cornerRadius: 10))
+            .contentShape(.rect(cornerRadius: 10))
+            .help(group.rootProject.path)
             .onHover { isHovering = $0 }
             .contextMenu {
                 if !group.rootProject.isTransientWorkspaceProject {
@@ -170,7 +213,7 @@ private struct ProjectGroupView: View {
         }
     }
 
-    private var projectCard: some View {
+    private var projectMainContent: some View {
         let dirName = URL(fileURLWithPath: group.rootProject.path).lastPathComponent
         let showSubtitle = dirName != group.rootProject.name
         let agentAccessory = WorkspaceAgentStatusAccessory(agentState: group.agentState, agentKind: group.agentKind)
@@ -215,44 +258,7 @@ private struct ProjectGroupView: View {
         .padding(.horizontal, 10)
         .padding(.vertical, 9)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(cardBg)
-        .overlay(alignment: .trailing) {
-            HStack(spacing: 4) {
-                groupStatusAccessory
-
-                HStack(spacing: 4) {
-                    if !group.rootProject.isTransientWorkspaceProject {
-                        iconButton(systemName: "arrow.clockwise", help: "刷新 worktree") {
-                            onRefreshWorktrees(group.rootProject.path)
-                        }
-                        iconButton(systemName: "plus", help: "创建或添加 worktree") {
-                            onRequestCreateWorktree(group.rootProject.path)
-                        }
-                    }
-                    iconButton(systemName: "xmark", help: "关闭项目") {
-                        onCloseProject(group.rootProject.path)
-                    }
-                }
-                .opacity(isHovering ? 1 : 0)
-                .animation(.easeInOut(duration: 0.15), value: isHovering)
-            }
-            .padding(.trailing, 6)
-            .padding(.vertical, 6)
-            .background(
-                LinearGradient(
-                    colors: [cardBg.opacity(0), cardBg, cardBg],
-                    startPoint: .leading,
-                    endPoint: .trailing
-                )
-            )
-        }
-        .overlay(
-            RoundedRectangle(cornerRadius: 10)
-                .stroke(group.isActive ? NativeTheme.accent.opacity(0.5) : NativeTheme.border.opacity(0.5), lineWidth: 1)
-        )
-        .clipShape(.rect(cornerRadius: 10))
         .contentShape(.rect(cornerRadius: 10))
-        .help(group.rootProject.path)
     }
 
     @ViewBuilder
@@ -359,19 +365,59 @@ private struct WorktreeRowView: View {
     @State private var isHovering = false
 
     var body: some View {
-        Button {
-            if item.status == "failed" || item.status == "creating" { return }
-            onOpenWorktree(item.rootProjectPath, item.path)
-        } label: {
-            rowContent
+        HStack(spacing: 6) {
+            Button {
+                guard item.displayState == .normal else { return }
+                onOpenWorktree(item.rootProjectPath, item.path)
+            } label: {
+                rowMainContent
+            }
+            .buttonStyle(.plain)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .contentShape(.rect(cornerRadius: 7))
+            .disabled({
+                if case .creating = item.displayState { return true }
+                return false
+            }())
+
+            HStack(spacing: 4) {
+                if case .failed = item.displayState {
+                    actionChip(title: "重试", help: item.initError ?? "重试创建") {
+                        onRetryWorktree(item.rootProjectPath, item.path)
+                    }
+                }
+                actionChip(title: "删除", help: "删除 worktree") {
+                    onRequestDeleteWorktree(item.rootProjectPath, item.path)
+                }
+            }
+            .allowsHitTesting(isHovering && {
+                if case .creating = item.displayState { return false }
+                return true
+            }())
+            .opacity(isHovering && {
+                if case .creating = item.displayState { return false }
+                return true
+            }() ? 1 : 0)
+            .animation(.easeInOut(duration: 0.15), value: isHovering)
+            .padding(.trailing, 6)
         }
-        .buttonStyle(.plain)
-        .disabled(item.status == "creating")
+        .frame(maxWidth: .infinity, alignment: .leading)
         .onHover { isHovering = $0 }
         .help(item.path)
+        .background(item.isActive ? NativeTheme.accent.opacity(0.1) : Color.clear)
+        .overlay(
+            RoundedRectangle(cornerRadius: 7)
+                .stroke(item.isActive ? NativeTheme.accent.opacity(0.4) : NativeTheme.border.opacity(0.4), lineWidth: 1)
+        )
+        .clipShape(.rect(cornerRadius: 7))
+        .contentShape(.rect(cornerRadius: 7))
+        .opacity({
+            if case .creating = item.displayState { return 0.7 }
+            return 1.0
+        }())
     }
 
-    private var rowContent: some View {
+    private var rowMainContent: some View {
         let agentAccessory = WorkspaceAgentStatusAccessory(agentState: item.agentState, agentKind: item.agentKind)
         return HStack(spacing: 6) {
             Image(systemName: "arrow.turn.down.right")
@@ -420,50 +466,25 @@ private struct WorktreeRowView: View {
                 }
             }
             Spacer(minLength: 4)
-            if item.branch != item.name {
-                Text(item.branch)
-                    .font(.caption2.monospaced())
-                    .foregroundStyle(NativeTheme.textSecondary.opacity(0.7))
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 2)
-                    .background(NativeTheme.surface.opacity(0.8))
-                    .clipShape(.rect(cornerRadius: 5))
-            }
+            Text(item.branch)
+                .font(.caption2.monospaced())
+                .foregroundStyle(NativeTheme.textSecondary.opacity(0.7))
+                .padding(.horizontal, 5)
+                .padding(.vertical, 2)
+                .background(NativeTheme.surface.opacity(0.8))
+                .clipShape(.rect(cornerRadius: 5))
             statusChip
         }
         .padding(.horizontal, 8)
         .padding(.vertical, 7)
         .frame(maxWidth: .infinity, alignment: .leading)
-        .background(item.isActive ? NativeTheme.accent.opacity(0.1) : Color.clear)
-        .overlay(alignment: .trailing) {
-            // 删除/重试按钮覆盖在行右侧
-            HStack(spacing: 4) {
-                if item.status == "failed" {
-                    actionChip(title: "重试", help: item.initError ?? "重试创建") {
-                        onRetryWorktree(item.rootProjectPath, item.path)
-                    }
-                }
-                actionChip(title: "删除", help: "删除 worktree") {
-                    onRequestDeleteWorktree(item.rootProjectPath, item.path)
-                }
-            }
-            .padding(.trailing, 6)
-            .opacity(isHovering && item.status != "creating" ? 1 : 0)
-            .animation(.easeInOut(duration: 0.15), value: isHovering)
-        }
-        .overlay(
-            RoundedRectangle(cornerRadius: 7)
-                .stroke(item.isActive ? NativeTheme.accent.opacity(0.4) : NativeTheme.border.opacity(0.4), lineWidth: 1)
-        )
-        .clipShape(.rect(cornerRadius: 7))
         .contentShape(.rect(cornerRadius: 7))
-        .opacity(item.status == "creating" ? 0.7 : 1)
     }
 
     @ViewBuilder
     private var statusChip: some View {
-        switch item.status {
-        case "creating":
+        switch item.displayState {
+        case .creating:
             Text("创建中")
                 .font(.caption2.weight(.medium))
                 .foregroundStyle(NativeTheme.warning)
@@ -471,7 +492,7 @@ private struct WorktreeRowView: View {
                 .padding(.vertical, 3)
                 .background(NativeTheme.warning.opacity(0.12))
                 .clipShape(.rect(cornerRadius: 6))
-        case "failed":
+        case .failed:
             Text("失败")
                 .font(.caption2.weight(.medium))
                 .foregroundStyle(NativeTheme.danger)
@@ -479,7 +500,7 @@ private struct WorktreeRowView: View {
                 .padding(.vertical, 3)
                 .background(NativeTheme.danger.opacity(0.12))
                 .clipShape(.rect(cornerRadius: 6))
-        default:
+        case .normal:
             EmptyView()
         }
     }

--- a/macos/Sources/DevHavenApp/WorkspaceProjectSidebarHostView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceProjectSidebarHostView.swift
@@ -2,15 +2,24 @@ import SwiftUI
 import DevHavenCore
 
 private struct WorktreeDeleteRequest: Identifiable, Equatable {
-    let rootProjectPath: String
-    let worktreePath: String
+    let presentation: WorkspaceWorktreeDeletePresentation
 
-    var id: String { "\(rootProjectPath)|\(worktreePath)" }
+    var rootProjectPath: String { presentation.rootProjectPath }
+    var worktreePath: String { presentation.worktreePath }
+    var id: String { presentation.id }
 }
 
 private struct WorkspaceDialogProject: Identifiable {
     let project: Project
     var id: String { project.path }
+}
+
+private struct DeferredWorktreeCreateRequest: Equatable {
+    let rootProjectPath: String
+    let branch: String
+    let createBranch: Bool
+    let baseBranch: String?
+    let autoOpen: Bool
 }
 
 private struct WorkspaceAlignmentEditorContext: Identifiable {
@@ -37,6 +46,7 @@ struct WorkspaceProjectSidebarHostView: View {
     @StateObject private var sidebarProjectionStore = WorkspaceSidebarProjectionStore()
     @State private var isProjectPickerPresented = false
     @State private var worktreeDialogProjectPath: String?
+    @State private var deferredWorktreeCreateRequest: DeferredWorktreeCreateRequest?
     @State private var pendingDeleteRequest: WorktreeDeleteRequest?
     @State private var alignmentEditorContext: WorkspaceAlignmentEditorContext?
     @State private var alignmentEditorIsSubmitting = false
@@ -94,7 +104,13 @@ struct WorkspaceProjectSidebarHostView: View {
                 }
             },
             onRequestDeleteWorktree: { rootProjectPath, worktreePath in
-                pendingDeleteRequest = WorktreeDeleteRequest(rootProjectPath: rootProjectPath, worktreePath: worktreePath)
+                guard let presentation = viewModel.workspaceWorktreeDeletePresentation(
+                    for: worktreePath,
+                    from: rootProjectPath
+                ) else {
+                    return
+                }
+                pendingDeleteRequest = WorktreeDeleteRequest(presentation: presentation)
             },
             onFocusNotification: viewModel.focusWorkspaceNotification,
             onCloseProject: viewModel.closeWorkspaceProject,
@@ -208,8 +224,14 @@ struct WorkspaceProjectSidebarHostView: View {
                 loadWorktrees: { try await viewModel.listProjectWorktrees(for: $0) },
                 managedPathPreview: { try viewModel.managedWorktreePathPreview(for: $0, branch: $1) },
                 onCreateWorktree: { branch, createBranch, baseBranch, autoOpen in
-                    try viewModel.startCreateWorkspaceWorktree(
+                    try viewModel.validateStartCreateWorkspaceWorktree(
                         from: dialogProject.project.path,
+                        branch: branch,
+                        createBranch: createBranch,
+                        baseBranch: baseBranch
+                    )
+                    deferredWorktreeCreateRequest = DeferredWorktreeCreateRequest(
+                        rootProjectPath: dialogProject.project.path,
                         branch: branch,
                         createBranch: createBranch,
                         baseBranch: baseBranch,
@@ -227,6 +249,26 @@ struct WorkspaceProjectSidebarHostView: View {
                 onClose: { worktreeDialogProjectPath = nil }
             )
             .preferredColorScheme(.dark)
+        }
+        .onChange(of: worktreeDialogProjectPath) { _, newValue in
+            guard newValue == nil, let request = deferredWorktreeCreateRequest else {
+                return
+            }
+            deferredWorktreeCreateRequest = nil
+            Task { @MainActor in
+                do {
+                    // 先关闭 `.sheet`，再启动创建任务；否则全局 overlay 会被 sheet 遮住，用户看不到进度面板。
+                    try viewModel.startCreateWorkspaceWorktree(
+                        from: request.rootProjectPath,
+                        branch: request.branch,
+                        createBranch: request.createBranch,
+                        baseBranch: request.baseBranch,
+                        autoOpen: request.autoOpen
+                    )
+                } catch {
+                    viewModel.errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                }
+            }
         }
         .sheet(item: $alignmentEditorContext) { context in
             WorkspaceAlignmentEditorSheet(
@@ -260,14 +302,14 @@ struct WorkspaceProjectSidebarHostView: View {
             .preferredColorScheme(.dark)
         }
         .confirmationDialog(
-            "删除 worktree",
+            pendingDeleteRequest?.presentation.title ?? "删除 worktree",
             isPresented: Binding(
                 get: { pendingDeleteRequest != nil },
                 set: { if !$0 { pendingDeleteRequest = nil } }
             ),
             titleVisibility: .visible
         ) {
-            Button("删除", role: .destructive) {
+            Button(pendingDeleteRequest?.presentation.actionTitle ?? "删除", role: .destructive) {
                 guard let pendingDeleteRequest else {
                     return
                 }
@@ -288,7 +330,7 @@ struct WorkspaceProjectSidebarHostView: View {
             }
         } message: {
             if let pendingDeleteRequest {
-                Text("将删除 \(pendingDeleteRequest.worktreePath)，并丢弃其中未提交修改与未跟踪文件。若该 worktree 由 DevHaven 创建，还会尝试删除对应本地分支。")
+                Text(pendingDeleteRequest.presentation.message)
             }
         }
         .alert(

--- a/macos/Sources/DevHavenCore/Models/NativeWorktreeModels.swift
+++ b/macos/Sources/DevHavenCore/Models/NativeWorktreeModels.swift
@@ -127,6 +127,95 @@ public struct NativeWorktreeRemoveResult: Equatable, Sendable {
     }
 }
 
+public struct NativeWorktreeEnvironmentResult: Equatable, Sendable {
+    public var warning: String?
+    public var executedCommands: [String]
+    public var failedCommand: String?
+    public var latestOutputLines: [String]
+
+    public init(
+        warning: String? = nil,
+        executedCommands: [String] = [],
+        failedCommand: String? = nil,
+        latestOutputLines: [String] = []
+    ) {
+        self.warning = warning
+        self.executedCommands = executedCommands
+        self.failedCommand = failedCommand
+        self.latestOutputLines = latestOutputLines
+    }
+}
+
+public struct NativeWorktreeCleanupRequest: Equatable, Sendable {
+    public var sourceProjectPath: String
+    public var worktreePath: String
+    public var branch: String?
+    public var shouldDeleteCreatedBranch: Bool
+
+    public init(
+        sourceProjectPath: String,
+        worktreePath: String,
+        branch: String? = nil,
+        shouldDeleteCreatedBranch: Bool
+    ) {
+        self.sourceProjectPath = sourceProjectPath
+        self.worktreePath = worktreePath
+        self.branch = branch
+        self.shouldDeleteCreatedBranch = shouldDeleteCreatedBranch
+    }
+}
+
+public struct NativeWorktreeCleanupResult: Equatable, Sendable {
+    public var removedWorktree: Bool
+    public var removedDirectory: Bool
+    public var removedBranch: Bool
+    public var warning: String?
+
+    public init(
+        removedWorktree: Bool = false,
+        removedDirectory: Bool = false,
+        removedBranch: Bool = false,
+        warning: String? = nil
+    ) {
+        self.removedWorktree = removedWorktree
+        self.removedDirectory = removedDirectory
+        self.removedBranch = removedBranch
+        self.warning = warning
+    }
+}
+
+public enum WorkspaceWorktreeDeleteKind: Equatable, Sendable {
+    case clearFailedCreation
+    case deletePersistedWorktree
+}
+
+public struct WorkspaceWorktreeDeletePresentation: Equatable, Sendable, Identifiable {
+    public var rootProjectPath: String
+    public var worktreePath: String
+    public var title: String
+    public var actionTitle: String
+    public var message: String
+    public var kind: WorkspaceWorktreeDeleteKind
+
+    public init(
+        rootProjectPath: String,
+        worktreePath: String,
+        title: String,
+        actionTitle: String,
+        message: String,
+        kind: WorkspaceWorktreeDeleteKind
+    ) {
+        self.rootProjectPath = rootProjectPath
+        self.worktreePath = worktreePath
+        self.title = title
+        self.actionTitle = actionTitle
+        self.message = message
+        self.kind = kind
+    }
+
+    public var id: String { "\(rootProjectPath)|\(worktreePath)|\(title)" }
+}
+
 public struct WorkspaceSidebarWorktreeItem: Equatable, Sendable, Identifiable {
     public var rootProjectPath: String
     public var worktree: ProjectWorktree
@@ -138,6 +227,10 @@ public struct WorkspaceSidebarWorktreeItem: Equatable, Sendable, Identifiable {
     public var agentState: WorkspaceAgentState?
     public var agentSummary: String?
     public var agentKind: WorkspaceAgentKind?
+    public var displayStateOverride: WorkspaceSidebarWorktreeDisplayState?
+    public var displayInitStepOverride: NativeWorktreeInitStep?
+    public var displayInitErrorOverride: String?
+    public var displayInitMessageOverride: String?
 
     public init(
         rootProjectPath: String,
@@ -149,7 +242,11 @@ public struct WorkspaceSidebarWorktreeItem: Equatable, Sendable, Identifiable {
         taskStatus: WorkspaceTaskStatus? = nil,
         agentState: WorkspaceAgentState? = nil,
         agentSummary: String? = nil,
-        agentKind: WorkspaceAgentKind? = nil
+        agentKind: WorkspaceAgentKind? = nil,
+        displayStateOverride: WorkspaceSidebarWorktreeDisplayState? = nil,
+        displayInitStepOverride: NativeWorktreeInitStep? = nil,
+        displayInitErrorOverride: String? = nil,
+        displayInitMessageOverride: String? = nil
     ) {
         self.rootProjectPath = rootProjectPath
         self.worktree = worktree
@@ -161,16 +258,40 @@ public struct WorkspaceSidebarWorktreeItem: Equatable, Sendable, Identifiable {
         self.agentState = agentState
         self.agentSummary = agentSummary
         self.agentKind = agentKind
+        self.displayStateOverride = displayStateOverride
+        self.displayInitStepOverride = displayInitStepOverride
+        self.displayInitErrorOverride = displayInitErrorOverride
+        self.displayInitMessageOverride = displayInitMessageOverride
     }
 
     public var id: String { worktree.id }
     public var path: String { worktree.path }
     public var name: String { worktree.name }
     public var branch: String { worktree.branch }
-    public var status: String? { worktree.status }
-    public var initStep: String? { worktree.initStep }
-    public var initError: String? { worktree.initError }
+    public var status: String? {
+        switch displayStateOverride {
+        case .creating:
+            "creating"
+        case .failed:
+            "failed"
+        case .normal, .none:
+            nil
+        }
+    }
+    public var initStep: String? { displayInitStepOverride?.rawValue }
+    public var initError: String? { displayInitErrorOverride }
+    public var initMessage: String? { displayInitMessageOverride }
     public var hasUnreadNotifications: Bool { unreadNotificationCount > 0 }
+
+    public var displayState: WorkspaceSidebarWorktreeDisplayState {
+        displayStateOverride ?? .normal
+    }
+}
+
+public enum WorkspaceSidebarWorktreeDisplayState: Equatable, Sendable {
+    case normal
+    case creating(message: String?)
+    case failed(message: String?)
 }
 
 public struct WorkspaceSidebarProjectGroup: Equatable, Sendable, Identifiable {
@@ -302,6 +423,7 @@ public enum NativeWorktreeError: LocalizedError, Equatable, Sendable {
 
 public protocol NativeWorktreeServicing: Sendable {
     func managedWorktreePath(for sourceProjectPath: String, branch: String) throws -> String
+    func preflightCreateWorktree(_ request: NativeWorktreeCreateRequest) throws -> String
     func currentBranch(at projectPath: String) throws -> String
     func listBranches(at projectPath: String) throws -> [NativeGitBranch]
     func listWorktrees(at projectPath: String) throws -> [NativeGitWorktree]
@@ -310,4 +432,13 @@ public protocol NativeWorktreeServicing: Sendable {
         progress: @escaping @Sendable (NativeWorktreeProgress) -> Void
     ) throws -> NativeWorktreeCreateResult
     func removeWorktree(_ request: NativeWorktreeRemoveRequest) throws -> NativeWorktreeRemoveResult
+    func cleanupFailedWorktreeCreate(_ request: NativeWorktreeCleanupRequest) throws -> NativeWorktreeCleanupResult
+}
+
+public protocol NativeWorktreeEnvironmentServicing: Sendable {
+    func prepareEnvironment(
+        mainRepositoryPath: String,
+        worktreePath: String,
+        workspaceName: String
+    ) -> NativeWorktreeEnvironmentResult
 }

--- a/macos/Sources/DevHavenCore/Storage/NativeGitWorktreeService.swift
+++ b/macos/Sources/DevHavenCore/Storage/NativeGitWorktreeService.swift
@@ -11,8 +11,30 @@ public struct NativeGitWorktreeService: NativeWorktreeServicing {
         try resolveTargetPath(sourceProjectPath: sourceProjectPath, branch: branch, explicitTargetPath: nil)
     }
 
+    public func preflightCreateWorktree(_ request: NativeWorktreeCreateRequest) throws -> String {
+        try ensureGitRepository(at: request.sourceProjectPath)
+        let branch = try normalizeBranchName(request.branch)
+        try validateBranchName(branch, at: request.sourceProjectPath)
+        let targetPath = try resolveTargetPath(
+            sourceProjectPath: request.sourceProjectPath,
+            branch: branch,
+            explicitTargetPath: request.targetPath
+        )
+        try validateTargetPath(targetPath, sourceProjectPath: request.sourceProjectPath)
+        try validateCreateRequest(request, branch: branch)
+        _ = try resolveCreateBranchStartPointIfNeeded(request, branch: branch)
+        return targetPath
+    }
+
     public func currentBranch(at projectPath: String) throws -> String {
         try ensureGitRepository(at: projectPath)
+        if let output = try? runGit(["symbolic-ref", "--quiet", "--short", "HEAD"], at: projectPath).stdout {
+            let branch = output.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !branch.isEmpty {
+                return branch
+            }
+        }
+
         let output = try runGit(["rev-parse", "--abbrev-ref", "HEAD"], at: projectPath).stdout
         let branch = output.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !branch.isEmpty else {
@@ -46,11 +68,13 @@ public struct NativeGitWorktreeService: NativeWorktreeServicing {
         try ensureGitRepository(at: request.sourceProjectPath)
 
         let branch = try normalizeBranchName(request.branch)
+        try validateBranchName(branch, at: request.sourceProjectPath)
         let targetPath = try resolveTargetPath(
             sourceProjectPath: request.sourceProjectPath,
             branch: branch,
             explicitTargetPath: request.targetPath
         )
+        try validateTargetPath(targetPath, sourceProjectPath: request.sourceProjectPath)
 
         progress(
             NativeWorktreeProgress(
@@ -88,22 +112,6 @@ public struct NativeGitWorktreeService: NativeWorktreeServicing {
                 worktreePath: targetPath,
                 branch: branch,
                 baseBranch: request.baseBranch,
-                step: .preparingEnvironment,
-                message: "执行中：准备工作区环境..."
-            )
-        )
-
-        let warning = prepareWorktreeEnvironment(
-            mainRepositoryPath: request.sourceProjectPath,
-            worktreePath: targetPath,
-            workspaceName: branch
-        )
-
-        progress(
-            NativeWorktreeProgress(
-                worktreePath: targetPath,
-                branch: branch,
-                baseBranch: request.baseBranch,
                 step: .syncing,
                 message: "执行中：同步工作区状态..."
             )
@@ -116,9 +124,8 @@ public struct NativeGitWorktreeService: NativeWorktreeServicing {
                 worktreePath: targetPath,
                 branch: branch,
                 baseBranch: request.baseBranch,
-                step: .ready,
-                message: warning == nil ? "创建完成" : "创建完成（环境初始化存在告警）",
-                error: warning
+                step: .syncing,
+                message: "Git worktree 已创建"
             )
         )
 
@@ -126,7 +133,7 @@ public struct NativeGitWorktreeService: NativeWorktreeServicing {
             worktreePath: targetPath,
             branch: branch,
             baseBranch: request.baseBranch,
-            warning: warning
+            warning: nil
         )
     }
 
@@ -160,6 +167,72 @@ public struct NativeGitWorktreeService: NativeWorktreeServicing {
         return try deleteBranchIfNeeded(for: request)
     }
 
+    public func cleanupFailedWorktreeCreate(_ request: NativeWorktreeCleanupRequest) throws -> NativeWorktreeCleanupResult {
+        try ensureGitRepository(at: request.sourceProjectPath)
+
+        let normalizedWorktreePath = normalizePathForCompare(request.worktreePath)
+        guard !normalizedWorktreePath.isEmpty else {
+            return NativeWorktreeCleanupResult(warning: "清理失败 worktree 时未提供有效路径")
+        }
+
+        var removedWorktree = false
+        var removedDirectory = false
+        var removedBranch = false
+        var warnings = [String]()
+
+        if let listed = try? listWorktrees(at: request.sourceProjectPath),
+           listed.contains(where: { normalizePathForCompare($0.path) == normalizedWorktreePath }) {
+            do {
+                _ = try runGit(["worktree", "remove", "--force", request.worktreePath], at: request.sourceProjectPath)
+                removedWorktree = true
+            } catch {
+                warnings.append("移除残留 worktree 失败：\(error.localizedDescription)")
+            }
+        }
+
+        if request.shouldDeleteCreatedBranch,
+           let branch = request.branch?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !branch.isEmpty {
+            let listedAfterRemove = (try? listWorktrees(at: request.sourceProjectPath)) ?? []
+            let branchOccupied = listedAfterRemove.contains(where: { $0.branch == branch })
+            if !branchOccupied {
+                let localBranches = (try? listBranches(at: request.sourceProjectPath).map(\.name)) ?? []
+                if localBranches.contains(branch) {
+                    do {
+                        _ = try runGit(["branch", "-D", branch], at: request.sourceProjectPath)
+                        removedBranch = true
+                    } catch {
+                        warnings.append("删除残留分支 \(branch) 失败：\(error.localizedDescription)")
+                    }
+                }
+            }
+        }
+
+        let targetURL = URL(fileURLWithPath: request.worktreePath)
+        if FileManager.default.fileExists(atPath: targetURL.path),
+           isManagedWorktreePath(request.worktreePath, for: request.sourceProjectPath) {
+            do {
+                try FileManager.default.removeItem(at: targetURL)
+                removedDirectory = true
+            } catch {
+                warnings.append("删除残留目录失败：\(error.localizedDescription)")
+            }
+        }
+
+        do {
+            _ = try runGit(["worktree", "prune"], at: request.sourceProjectPath)
+        } catch {
+            warnings.append("执行 git worktree prune 失败：\(error.localizedDescription)")
+        }
+
+        return NativeWorktreeCleanupResult(
+            removedWorktree: removedWorktree,
+            removedDirectory: removedDirectory,
+            removedBranch: removedBranch,
+            warning: warnings.isEmpty ? nil : warnings.joined(separator: "\n")
+        )
+    }
+
     private func deleteBranchIfNeeded(for request: NativeWorktreeRemoveRequest) throws -> NativeWorktreeRemoveResult {
         guard request.shouldDeleteBranch, let branch = request.branch?.trimmingCharacters(in: .whitespacesAndNewlines), !branch.isEmpty else {
             return NativeWorktreeRemoveResult(warning: nil)
@@ -170,6 +243,17 @@ public struct NativeGitWorktreeService: NativeWorktreeServicing {
             return NativeWorktreeRemoveResult(warning: nil)
         } catch let error as NativeWorktreeError {
             if case let .commandFailed(message) = error {
+                if shouldForceDeleteBranchAfterSafeDeleteFailure(message) {
+                    do {
+                        _ = try runGit(["branch", "-D", branch], at: request.sourceProjectPath)
+                        return NativeWorktreeRemoveResult(warning: nil)
+                    } catch let forcedError as NativeWorktreeError {
+                        if case let .commandFailed(forcedMessage) = forcedError {
+                            return NativeWorktreeRemoveResult(warning: normalizeDeleteBranchError(forcedMessage))
+                        }
+                        throw forcedError
+                    }
+                }
                 return NativeWorktreeRemoveResult(warning: normalizeDeleteBranchError(message))
             }
             throw error
@@ -288,7 +372,16 @@ public struct NativeGitWorktreeService: NativeWorktreeServicing {
     private func resolveTargetPath(sourceProjectPath: String, branch: String, explicitTargetPath: String?) throws -> String {
         let trimmed = explicitTargetPath?.trimmingCharacters(in: .whitespacesAndNewlines)
         if let trimmed, !trimmed.isEmpty {
-            return trimmed
+            guard NSString(string: trimmed).isAbsolutePath else {
+                throw NativeWorktreeError.invalidPath("目标路径必须是绝对路径")
+            }
+            let explicitURL = URL(fileURLWithPath: trimmed, isDirectory: true)
+            let normalizedExplicitPath = explicitURL.standardizedFileURL.path()
+            let normalizedSourcePath = URL(fileURLWithPath: sourceProjectPath, isDirectory: true).standardizedFileURL.path()
+            guard normalizePathForCompare(normalizedExplicitPath) != normalizePathForCompare(normalizedSourcePath) else {
+                throw NativeWorktreeError.invalidPath("目标目录不能与主仓库目录相同")
+            }
+            return normalizedExplicitPath
         }
 
         let normalizedBranch = branch
@@ -337,6 +430,59 @@ public struct NativeGitWorktreeService: NativeWorktreeServicing {
         let gitURL = URL(fileURLWithPath: projectPath).appending(path: ".git")
         guard FileManager.default.fileExists(atPath: gitURL.path) else {
             throw NativeWorktreeError.invalidRepository("不是 Git 仓库")
+        }
+    }
+
+    private func validateBranchName(_ branch: String, at projectPath: String) throws {
+        if branch.contains(where: \.isWhitespace) {
+            throw NativeWorktreeError.invalidBranch("分支名不能包含空格")
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git", "check-ref-format", "--branch", branch]
+        process.currentDirectoryURL = URL(fileURLWithPath: projectPath, isDirectory: true)
+        let stderr = Pipe()
+        process.standardError = stderr
+
+        do {
+            try process.run()
+        } catch {
+            throw NativeWorktreeError.invalidBranch("分支名不合法：\(error.localizedDescription)")
+        }
+        process.waitUntilExit()
+
+        guard process.terminationStatus == 0 else {
+            let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?
+                .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+            if stderrText.isEmpty {
+                throw NativeWorktreeError.invalidBranch("分支名不合法，请检查后重试")
+            }
+            throw NativeWorktreeError.invalidBranch("分支名不合法：\(stderrText)")
+        }
+    }
+
+    private func validateTargetPath(_ targetPath: String, sourceProjectPath: String) throws {
+        let normalizedTargetPath = normalizePathForCompare(targetPath)
+        guard !normalizedTargetPath.isEmpty else {
+            throw NativeWorktreeError.invalidPath("目标路径不能为空")
+        }
+        let normalizedSourcePath = normalizePathForCompare(sourceProjectPath)
+        if normalizedTargetPath == normalizedSourcePath {
+            throw NativeWorktreeError.invalidPath("目标路径不能与主仓库目录相同")
+        }
+        let managedRoot = normalizePathForCompare(
+            homeDirectoryURL
+                .appending(path: ".devhaven", directoryHint: .isDirectory)
+                .appending(path: "worktrees", directoryHint: .isDirectory)
+                .appending(path: resolveRepositoryName(sourceProjectPath), directoryHint: .isDirectory)
+                .path()
+        )
+        let targetComponents = URL(fileURLWithPath: normalizedTargetPath).standardizedFileURL.pathComponents
+        let rootComponents = URL(fileURLWithPath: managedRoot).standardizedFileURL.pathComponents
+        guard targetComponents.count >= rootComponents.count,
+              Array(targetComponents.prefix(rootComponents.count)) == rootComponents else {
+            throw NativeWorktreeError.invalidPath("目标路径必须位于 DevHaven 管理的 worktree 目录内")
         }
     }
 
@@ -503,6 +649,20 @@ public struct NativeGitWorktreeService: NativeWorktreeServicing {
         return normalized
     }
 
+    private func isManagedWorktreePath(_ worktreePath: String, for sourceProjectPath: String) -> Bool {
+        let managedRoot = homeDirectoryURL
+            .appending(path: ".devhaven", directoryHint: .isDirectory)
+            .appending(path: "worktrees", directoryHint: .isDirectory)
+            .appending(path: resolveRepositoryName(sourceProjectPath), directoryHint: .isDirectory)
+
+        let normalizedTarget = URL(fileURLWithPath: worktreePath).standardizedFileURL.pathComponents
+        let normalizedRoot = managedRoot.standardizedFileURL.pathComponents
+        guard normalizedTarget.count >= normalizedRoot.count else {
+            return false
+        }
+        return Array(normalizedTarget.prefix(normalizedRoot.count)) == normalizedRoot
+    }
+
     private func shouldPruneAfterRemoveFailure(_ raw: String) -> Bool {
         let lower = raw.lowercased()
         return lower.contains("not a working tree") || lower.contains("is missing") || lower.contains("no such file or directory")
@@ -545,119 +705,10 @@ public struct NativeGitWorktreeService: NativeWorktreeServicing {
         return raw
     }
 
-    private func prepareWorktreeEnvironment(mainRepositoryPath: String, worktreePath: String, workspaceName: String) -> String? {
-        var warnings = [String]()
-        if let error = copySetupDirectory(mainRepositoryPath: mainRepositoryPath, worktreePath: worktreePath) {
-            warnings.append(error)
-        }
-        if let error = runSetupCommandsIfNeeded(mainRepositoryPath: mainRepositoryPath, worktreePath: worktreePath, workspaceName: workspaceName) {
-            warnings.append(error)
-        }
-        return warnings.isEmpty ? nil : warnings.joined(separator: "\n")
+    private func shouldForceDeleteBranchAfterSafeDeleteFailure(_ raw: String) -> Bool {
+        raw.lowercased().contains("not fully merged")
     }
 
-    private func copySetupDirectory(mainRepositoryPath: String, worktreePath: String) -> String? {
-        let sourceURL = URL(fileURLWithPath: mainRepositoryPath).appending(path: ".devhaven", directoryHint: .isDirectory)
-        let targetURL = URL(fileURLWithPath: worktreePath).appending(path: ".devhaven", directoryHint: .isDirectory)
-        guard FileManager.default.fileExists(atPath: sourceURL.path) else {
-            return nil
-        }
-        guard !FileManager.default.fileExists(atPath: targetURL.path) else {
-            return nil
-        }
-
-        do {
-            try copyDirectoryRecursively(from: sourceURL, to: targetURL)
-            return nil
-        } catch {
-            return "复制 .devhaven 目录失败：\(error.localizedDescription)"
-        }
-    }
-
-    private func copyDirectoryRecursively(from sourceURL: URL, to targetURL: URL) throws {
-        try FileManager.default.createDirectory(at: targetURL, withIntermediateDirectories: true)
-        for entry in try FileManager.default.contentsOfDirectory(at: sourceURL, includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey]) {
-            let destinationURL = targetURL.appending(path: entry.lastPathComponent)
-            let values = try entry.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
-            if values.isDirectory == true {
-                try copyDirectoryRecursively(from: entry, to: destinationURL)
-                continue
-            }
-            if values.isSymbolicLink == true {
-                let metadata = try FileManager.default.attributesOfItem(atPath: entry.path)
-                if metadata[.type] as? FileAttributeType == .typeDirectory {
-                    continue
-                }
-            }
-            if FileManager.default.fileExists(atPath: destinationURL.path) {
-                try FileManager.default.removeItem(at: destinationURL)
-            }
-            try FileManager.default.copyItem(at: entry, to: destinationURL)
-        }
-    }
-
-    private func runSetupCommandsIfNeeded(mainRepositoryPath: String, worktreePath: String, workspaceName: String) -> String? {
-        let configURL = URL(fileURLWithPath: mainRepositoryPath)
-            .appending(path: ".devhaven", directoryHint: .isDirectory)
-            .appending(path: "config.json")
-        guard FileManager.default.fileExists(atPath: configURL.path) else {
-            return nil
-        }
-
-        let commands: [String]
-        do {
-            commands = try loadSetupCommands(configURL: configURL)
-        } catch {
-            return error.localizedDescription
-        }
-        guard !commands.isEmpty else {
-            return nil
-        }
-
-        for command in commands {
-            let process = Process()
-            process.executableURL = URL(fileURLWithPath: ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh")
-            process.arguments = ["-lc", command]
-            process.currentDirectoryURL = URL(fileURLWithPath: worktreePath, isDirectory: true)
-            process.environment = ProcessInfo.processInfo.environment.merging([
-                "DEVHAVEN_WORKSPACE_NAME": workspaceName,
-                "DEVHAVEN_ROOT_PATH": mainRepositoryPath,
-            ]) { _, new in new }
-
-            let stdout = Pipe()
-            let stderr = Pipe()
-            process.standardOutput = stdout
-            process.standardError = stderr
-            do {
-                try process.run()
-            } catch {
-                return "执行 setup 命令失败（\(command)）：\(error.localizedDescription)"
-            }
-            process.waitUntilExit()
-            guard process.terminationStatus == 0 else {
-                let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8)?.trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
-                let combined = [stdoutText.isEmpty ? nil : "stdout:\n\(stdoutText)", stderrText.isEmpty ? nil : "stderr:\n\(stderrText)"]
-                    .compactMap { $0 }
-                    .joined(separator: "\n\n")
-                return "环境初始化命令执行失败：\n$ \(command)\n退出码：\(process.terminationStatus)\n\(combined.isEmpty ? "命令无输出" : combined)"
-            }
-        }
-
-        return nil
-    }
-
-    private func loadSetupCommands(configURL: URL) throws -> [String] {
-        struct SetupConfig: Decodable {
-            var setup: [String] = []
-        }
-
-        let data = try Data(contentsOf: configURL)
-        let parsed = try JSONDecoder().decode(SetupConfig.self, from: data)
-        return parsed.setup
-            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
-            .filter { !$0.isEmpty }
-    }
 }
 
 private struct ProcessOutput {

--- a/macos/Sources/DevHavenCore/Storage/NativeWorktreeEnvironmentService.swift
+++ b/macos/Sources/DevHavenCore/Storage/NativeWorktreeEnvironmentService.swift
@@ -1,0 +1,174 @@
+import Foundation
+
+public struct NativeWorktreeEnvironmentService: NativeWorktreeEnvironmentServicing {
+    public init() {}
+
+    public func prepareEnvironment(
+        mainRepositoryPath: String,
+        worktreePath: String,
+        workspaceName: String
+    ) -> NativeWorktreeEnvironmentResult {
+        var warnings = [String]()
+        if let error = copySetupDirectory(mainRepositoryPath: mainRepositoryPath, worktreePath: worktreePath) {
+            warnings.append(error)
+        }
+
+        let commandResult = runSetupCommandsIfNeeded(
+            mainRepositoryPath: mainRepositoryPath,
+            worktreePath: worktreePath,
+            workspaceName: workspaceName
+        )
+        if let error = commandResult.warning {
+            warnings.append(error)
+        }
+
+        let warning = warnings
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .joined(separator: "\n")
+
+        return NativeWorktreeEnvironmentResult(
+            warning: warning.isEmpty ? nil : warning,
+            executedCommands: commandResult.executedCommands,
+            failedCommand: commandResult.failedCommand,
+            latestOutputLines: commandResult.latestOutputLines
+        )
+    }
+
+    private func copySetupDirectory(mainRepositoryPath: String, worktreePath: String) -> String? {
+        let sourceURL = URL(fileURLWithPath: mainRepositoryPath).appending(path: ".devhaven", directoryHint: .isDirectory)
+        let targetURL = URL(fileURLWithPath: worktreePath).appending(path: ".devhaven", directoryHint: .isDirectory)
+        guard FileManager.default.fileExists(atPath: sourceURL.path) else {
+            return nil
+        }
+        guard !FileManager.default.fileExists(atPath: targetURL.path) else {
+            return nil
+        }
+
+        do {
+            try copyDirectoryRecursively(from: sourceURL, to: targetURL)
+            return nil
+        } catch {
+            return "复制 .devhaven 目录失败：\(error.localizedDescription)"
+        }
+    }
+
+    private func copyDirectoryRecursively(from sourceURL: URL, to targetURL: URL) throws {
+        try FileManager.default.createDirectory(at: targetURL, withIntermediateDirectories: true)
+        for entry in try FileManager.default.contentsOfDirectory(at: sourceURL, includingPropertiesForKeys: [.isDirectoryKey, .isSymbolicLinkKey]) {
+            let destinationURL = targetURL.appending(path: entry.lastPathComponent)
+            let values = try entry.resourceValues(forKeys: [.isDirectoryKey, .isSymbolicLinkKey])
+            if values.isDirectory == true {
+                try copyDirectoryRecursively(from: entry, to: destinationURL)
+                continue
+            }
+            if values.isSymbolicLink == true {
+                let metadata = try FileManager.default.attributesOfItem(atPath: entry.path)
+                if metadata[.type] as? FileAttributeType == .typeDirectory {
+                    continue
+                }
+            }
+            if FileManager.default.fileExists(atPath: destinationURL.path) {
+                try FileManager.default.removeItem(at: destinationURL)
+            }
+            try FileManager.default.copyItem(at: entry, to: destinationURL)
+        }
+    }
+
+    private func runSetupCommandsIfNeeded(
+        mainRepositoryPath: String,
+        worktreePath: String,
+        workspaceName: String
+    ) -> NativeWorktreeEnvironmentResult {
+        let configURL = URL(fileURLWithPath: mainRepositoryPath)
+            .appending(path: ".devhaven", directoryHint: .isDirectory)
+            .appending(path: "config.json")
+        guard FileManager.default.fileExists(atPath: configURL.path) else {
+            return NativeWorktreeEnvironmentResult()
+        }
+
+        let commands: [String]
+        do {
+            commands = try loadSetupCommands(configURL: configURL)
+        } catch {
+            return NativeWorktreeEnvironmentResult(warning: error.localizedDescription)
+        }
+        guard !commands.isEmpty else {
+            return NativeWorktreeEnvironmentResult()
+        }
+
+        var executedCommands = [String]()
+        var latestOutputLines = [String]()
+        for command in commands {
+            executedCommands.append(command)
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: ProcessInfo.processInfo.environment["SHELL"] ?? "/bin/zsh")
+            process.arguments = ["-lc", command]
+            process.currentDirectoryURL = URL(fileURLWithPath: worktreePath, isDirectory: true)
+            process.environment = ProcessInfo.processInfo.environment.merging([
+                "DEVHAVEN_WORKSPACE_NAME": workspaceName,
+                "DEVHAVEN_ROOT_PATH": mainRepositoryPath,
+            ]) { _, new in new }
+
+            let stdout = Pipe()
+            let stderr = Pipe()
+            process.standardOutput = stdout
+            process.standardError = stderr
+            do {
+                try process.run()
+            } catch {
+                return NativeWorktreeEnvironmentResult(
+                    warning: "执行 setup 命令失败（\(command)）：\(error.localizedDescription)",
+                    executedCommands: executedCommands,
+                    failedCommand: command,
+                    latestOutputLines: latestOutputLines
+                )
+            }
+            process.waitUntilExit()
+
+            let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+            latestOutputLines = summarizeOutputLines(stdout: stdoutText, stderr: stderrText)
+
+            guard process.terminationStatus == 0 else {
+                return NativeWorktreeEnvironmentResult(
+                    warning: "环境初始化命令执行失败：\n$ \(command)\n退出码：\(process.terminationStatus)",
+                    executedCommands: executedCommands,
+                    failedCommand: command,
+                    latestOutputLines: latestOutputLines.isEmpty ? ["命令无输出"] : latestOutputLines
+                )
+            }
+        }
+
+        return NativeWorktreeEnvironmentResult(
+            executedCommands: executedCommands,
+            latestOutputLines: latestOutputLines
+        )
+    }
+
+    private func summarizeOutputLines(stdout: String, stderr: String, limit: Int = 5) -> [String] {
+        let stdoutLines = stdout
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .map { "stdout | \($0)" }
+        let stderrLines = stderr
+            .split(whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+            .map { "stderr | \($0)" }
+        return Array((stdoutLines + stderrLines).suffix(limit))
+    }
+
+    private func loadSetupCommands(configURL: URL) throws -> [String] {
+        struct SetupConfig: Decodable {
+            var setup: [String] = []
+        }
+
+        let data = try Data(contentsOf: configURL)
+        let parsed = try JSONDecoder().decode(SetupConfig.self, from: data)
+        return parsed.setup
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+    }
+}

--- a/macos/Sources/DevHavenCore/ViewModels/NativeAppViewModel.swift
+++ b/macos/Sources/DevHavenCore/ViewModels/NativeAppViewModel.swift
@@ -7,6 +7,25 @@ private struct WorktreeCreateContext {
     let previewPath: String
 }
 
+private enum PendingWorkspaceWorktreeCreateStatus: String, Equatable, Sendable {
+    case creating
+    case failed
+}
+
+private struct PendingWorkspaceWorktreeCreateState: Equatable {
+    let rootProjectPath: String
+    let branch: String
+    let baseBranch: String?
+    let worktreePath: String
+    let createBranch: Bool
+    let jobID: String
+    let createdAt: SwiftDate
+    var status: PendingWorkspaceWorktreeCreateStatus
+    var step: NativeWorktreeInitStep
+    var message: String
+    var error: String?
+}
+
 private struct WorkspaceAlignmentStatusProbe: Sendable {
     let projectPath: String
     let targetBranch: String
@@ -46,6 +65,7 @@ public final class NativeAppViewModel {
     @ObservationIgnored private let projectImportDiagnostics: ProjectImportDiagnostics
     @ObservationIgnored private let terminalCommandRunner: @Sendable (String, [String]) throws -> Void
     @ObservationIgnored private let worktreeService: any NativeWorktreeServicing
+    @ObservationIgnored private let worktreeEnvironmentService: any NativeWorktreeEnvironmentServicing
     @ObservationIgnored private let gitRepositoryService: NativeGitRepositoryService
     @ObservationIgnored private let agentSignalStore: WorkspaceAgentSignalStore
     @ObservationIgnored private let runManager: any WorkspaceRunManaging
@@ -152,6 +172,11 @@ public final class NativeAppViewModel {
             noteWorkspaceSidebarProjectionMutation(from: oldValue, to: currentBranchByProjectPath)
         }
     }
+    private var pendingWorkspaceWorktreeCreatesByPath: [String: PendingWorkspaceWorktreeCreateState] {
+        didSet {
+            noteWorkspaceSidebarProjectionMutation(from: oldValue, to: pendingWorkspaceWorktreeCreatesByPath)
+        }
+    }
     private var workspaceAlignmentStatusByKey: [String: WorkspaceAlignmentMemberStatus] {
         didSet {
             noteWorkspaceSidebarProjectionMutation(from: oldValue, to: workspaceAlignmentStatusByKey)
@@ -195,6 +220,7 @@ public final class NativeAppViewModel {
         projectImportDiagnostics: ProjectImportDiagnostics = .shared,
         terminalCommandRunner: (@Sendable (String, [String]) throws -> Void)? = nil,
         worktreeService: (any NativeWorktreeServicing)? = nil,
+        worktreeEnvironmentService: (any NativeWorktreeEnvironmentServicing)? = nil,
         gitRepositoryService: NativeGitRepositoryService = NativeGitRepositoryService(),
         agentSignalStore: WorkspaceAgentSignalStore? = nil,
         runManager: (any WorkspaceRunManaging)? = nil,
@@ -211,6 +237,7 @@ public final class NativeAppViewModel {
         self.projectImportDiagnostics = projectImportDiagnostics
         self.terminalCommandRunner = terminalCommandRunner ?? Self.runTerminalCommand
         self.worktreeService = worktreeService ?? NativeGitWorktreeService()
+        self.worktreeEnvironmentService = worktreeEnvironmentService ?? NativeWorktreeEnvironmentService()
         self.gitRepositoryService = gitRepositoryService
         self.agentSignalStore = agentSignalStore ?? WorkspaceAgentSignalStore(
             baseDirectoryURL: store.agentStatusSessionsDirectoryURL
@@ -240,6 +267,7 @@ public final class NativeAppViewModel {
         self.agentDisplayOverridesByProjectPath = [:]
         self.workspaceRunConsoleStateByProjectPath = [:]
         self.currentBranchByProjectPath = [:]
+        self.pendingWorkspaceWorktreeCreatesByPath = [:]
         self.workspaceAlignmentStatusByKey = [:]
         self.workspaceCommitViewModels = [:]
         self.workspaceGitViewModels = [:]
@@ -860,24 +888,20 @@ public final class NativeAppViewModel {
     }
 
     public var activeWorkspaceController: GhosttyWorkspaceController? {
-        guard let activeWorkspaceProjectPath else {
-            return nil
-        }
-        return openWorkspaceSessions.first(where: { $0.projectPath == activeWorkspaceProjectPath })?.controller
+        workspaceController(for: activeWorkspaceProjectPath)
     }
 
     public var activeWorkspaceRootProjectPath: String? {
-        guard let activeWorkspaceProjectPath else {
-            return nil
-        }
-        return openWorkspaceSessions.first(where: { $0.projectPath == activeWorkspaceProjectPath })?.rootProjectPath
+        workspaceSession(for: activeWorkspaceProjectPath)?.rootProjectPath
     }
 
     public var activeWorkspaceRootProject: Project? {
         guard let activeWorkspaceRootProjectPath else {
             return nil
         }
-        return snapshot.projects.first(where: { $0.path == activeWorkspaceRootProjectPath })
+        return snapshot.projects.first(where: {
+            normalizePathForCompare($0.path) == normalizePathForCompare(activeWorkspaceRootProjectPath)
+        })
     }
 
     public var activeWorkspaceGitRepositoryContext: WorkspaceGitRepositoryContext? {
@@ -1311,7 +1335,7 @@ public final class NativeAppViewModel {
     }
 
     public func closeWorkspaceProject(_ path: String) {
-        guard let index = openWorkspaceSessions.firstIndex(where: { $0.projectPath == path }) else {
+        guard let index = workspaceSessionIndex(for: path) else {
             return
         }
 
@@ -1414,6 +1438,16 @@ public final class NativeAppViewModel {
         let normalizedRootProjectPath = normalizePathForCompare(rootProjectPath)
         let normalizedWorktreePath = normalizePathForCompare(worktreePath)
 
+        if let pending = pendingWorkspaceWorktreeCreatesByPath[normalizedWorktreePath],
+           normalizePathForCompare(pending.rootProjectPath) == normalizedRootProjectPath {
+            if pending.status == .creating {
+                errorMessage = "该 worktree 正在创建中，请稍候"
+            } else {
+                errorMessage = pending.error ?? "该 worktree 创建失败，请先重试"
+            }
+            return
+        }
+
         guard let rootProject = snapshot.projects.first(where: {
             normalizePathForCompare($0.path) == normalizedRootProjectPath
         }) else {
@@ -1425,14 +1459,6 @@ public final class NativeAppViewModel {
             normalizePathForCompare($0.path) == normalizedWorktreePath
         }) else {
             errorMessage = NativeWorktreeError.invalidPath("worktree 不存在或已移除").localizedDescription
-            return
-        }
-        if worktree.status == "creating" {
-            errorMessage = "该 worktree 正在创建中，请稍候"
-            return
-        }
-        if worktree.status == "failed" {
-            errorMessage = worktree.initError ?? "该 worktree 创建失败，请先重试"
             return
         }
         if workspaceAlignmentGroupID == nil {
@@ -1909,9 +1935,8 @@ public final class NativeAppViewModel {
         guard snapshot.projects.contains(where: { normalizePathForCompare($0.path) == normalizedRootProjectPath }) else {
             throw NativeWorktreeError.invalidProject("项目不存在或已移除")
         }
-        async let gitWorktrees = listProjectWorktrees(for: normalizedRootProjectPath)
-        async let currentBranch = currentWorkspaceBranch(for: normalizedRootProjectPath)
-        let (resolvedWorktrees, resolvedCurrentBranch) = try await (gitWorktrees, currentBranch)
+        let resolvedWorktrees = try await listProjectWorktrees(for: normalizedRootProjectPath)
+        let resolvedCurrentBranch = try? await currentWorkspaceBranch(for: normalizedRootProjectPath)
         try syncProjectRepositoryState(
             rootProjectPath: normalizedRootProjectPath,
             gitWorktrees: resolvedWorktrees,
@@ -2148,7 +2173,24 @@ public final class NativeAppViewModel {
             baseBranch: baseBranch,
             targetPath: targetPath
         )
+        try beginCreateWorkspaceWorktree(context)
         try await runCreateWorkspaceWorktree(context, autoOpen: autoOpen)
+    }
+
+    public func validateStartCreateWorkspaceWorktree(
+        from rootProjectPath: String,
+        branch: String,
+        createBranch: Bool,
+        baseBranch: String?,
+        targetPath: String? = nil
+    ) throws {
+        _ = try prepareCreateWorkspaceWorktree(
+            from: rootProjectPath,
+            branch: branch,
+            createBranch: createBranch,
+            baseBranch: baseBranch,
+            targetPath: targetPath
+        )
     }
 
     public func startCreateWorkspaceWorktree(
@@ -2166,14 +2208,22 @@ public final class NativeAppViewModel {
             baseBranch: baseBranch,
             targetPath: targetPath
         )
-        Task { [weak self] in
+        Task { @MainActor [weak self] in
             guard let self else {
                 return
             }
+            var didBeginCreate = false
             do {
+                await Task.yield()
+                try self.beginCreateWorkspaceWorktree(context)
+                didBeginCreate = true
                 try await self.runCreateWorkspaceWorktree(context, autoOpen: autoOpen)
             } catch {
-                // `runCreateWorkspaceWorktree` 已把失败状态、错误文案和交互锁清理回主状态，这里无需重复处理。
+                guard !didBeginCreate else {
+                    // `runCreateWorkspaceWorktree` 已把失败状态、错误文案和交互锁清理回主状态，这里无需重复处理。
+                    return
+                }
+                self.errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
             }
         }
     }
@@ -2188,7 +2238,7 @@ public final class NativeAppViewModel {
         guard worktreeInteractionState == nil else {
             throw NativeWorktreeError.operationInProgress("已有 worktree 创建任务正在进行中，请稍候")
         }
-        guard let projectIndex = snapshot.projects.firstIndex(where: { $0.path == rootProjectPath }) else {
+        guard snapshot.projects.contains(where: { $0.path == rootProjectPath }) else {
             throw NativeWorktreeError.invalidProject("项目不存在或已移除")
         }
 
@@ -2199,40 +2249,50 @@ public final class NativeAppViewModel {
             baseBranch: baseBranch,
             targetPath: targetPath
         )
-        let previewPath = try worktreeService.managedWorktreePath(for: rootProjectPath, branch: branch)
-        let now = swiftDateFromDate(Date())
-        let creatingWorktree = ProjectWorktree(
-            id: createWorktreeProjectID(path: previewPath),
-            name: resolveWorktreeName(previewPath),
-            path: previewPath,
-            branch: branch.trimmingCharacters(in: .whitespacesAndNewlines),
-            baseBranch: createBranch ? baseBranch?.trimmingCharacters(in: .whitespacesAndNewlines) : nil,
-            inheritConfig: true,
-            created: now,
-            status: "creating",
-            initStep: NativeWorktreeInitStep.pending.rawValue,
-            initMessage: "已创建任务，准备开始…",
-            initError: nil,
-            initJobId: UUID().uuidString,
-            updatedAt: now
-        )
-
-        var projects = snapshot.projects
-        upsertWorktree(&projects[projectIndex].worktrees, worktree: creatingWorktree)
-        try persistProjects(projects)
-        worktreeInteractionState = WorktreeInteractionState(
-            rootProjectPath: rootProjectPath,
-            branch: creatingWorktree.branch,
-            baseBranch: creatingWorktree.baseBranch,
-            worktreePath: creatingWorktree.path,
-            step: .pending,
-            message: "准备创建 worktree..."
-        )
+        let previewPath = try worktreeService.preflightCreateWorktree(request)
 
         return WorktreeCreateContext(
             request: request,
             rootProjectPath: rootProjectPath,
             previewPath: previewPath
+        )
+    }
+
+    private func beginCreateWorkspaceWorktree(_ context: WorktreeCreateContext) throws {
+        guard worktreeInteractionState == nil else {
+            throw NativeWorktreeError.operationInProgress("已有 worktree 创建任务正在进行中，请稍候")
+        }
+        guard snapshot.projects.contains(where: { $0.path == context.rootProjectPath }) else {
+            throw NativeWorktreeError.invalidProject("项目不存在或已移除")
+        }
+
+        let now = swiftDateFromDate(Date())
+        let jobID = UUID().uuidString
+        let normalizedPreviewPath = normalizePathForCompare(context.previewPath)
+        let trimmedBranch = context.request.branch.trimmingCharacters(in: .whitespacesAndNewlines)
+        let trimmedBaseBranch = context.request.createBranch
+            ? context.request.baseBranch?.trimmingCharacters(in: .whitespacesAndNewlines)
+            : nil
+        pendingWorkspaceWorktreeCreatesByPath[normalizedPreviewPath] = PendingWorkspaceWorktreeCreateState(
+            rootProjectPath: context.rootProjectPath,
+            branch: trimmedBranch,
+            baseBranch: trimmedBaseBranch,
+            worktreePath: context.previewPath,
+            createBranch: context.request.createBranch,
+            jobID: jobID,
+            createdAt: now,
+            status: .creating,
+            step: .pending,
+            message: "已创建任务，准备开始…",
+            error: nil
+        )
+        worktreeInteractionState = WorktreeInteractionState(
+            rootProjectPath: context.rootProjectPath,
+            branch: trimmedBranch,
+            baseBranch: trimmedBaseBranch,
+            worktreePath: context.previewPath,
+            step: .pending,
+            message: "准备创建 worktree..."
         )
     }
 
@@ -2248,10 +2308,13 @@ public final class NativeAppViewModel {
                     }
                 }
             }.value
+            try await refreshProjectWorktrees(context.rootProjectPath)
+            let bootstrapResult = await prepareWorkspaceWorktreeEnvironment(context)
 
             finishCreateWorkspaceWorktree(
                 result,
                 rootProjectPath: context.rootProjectPath,
+                bootstrapResult: bootstrapResult,
                 autoOpen: autoOpen
             )
         } catch {
@@ -2261,15 +2324,38 @@ public final class NativeAppViewModel {
                 rootProjectPath: context.rootProjectPath,
                 errorMessage: message
             )
+            let cleanupWarning = cleanupFailedWorkspaceWorktreeCreate(context)
+            try? await refreshProjectWorktrees(context.rootProjectPath)
             worktreeInteractionState = nil
-            errorMessage = message
+            if let cleanupWarning, !cleanupWarning.isEmpty {
+                errorMessage = "\(message)\n\n清理残留状态时出现告警：\n\(cleanupWarning)"
+            } else {
+                errorMessage = message
+            }
             throw error
         }
     }
 
     public func retryWorkspaceWorktree(_ worktreePath: String, from rootProjectPath: String) async throws {
+        let normalizedWorktreePath = normalizePathForCompare(worktreePath)
+        if let pending = pendingWorkspaceWorktreeCreatesByPath[normalizedWorktreePath] {
+            guard pending.status != .creating else {
+                throw NativeWorktreeError.operationInProgress("该 worktree 正在创建中，请稍候")
+            }
+            pendingWorkspaceWorktreeCreatesByPath.removeValue(forKey: normalizedWorktreePath)
+            try await createWorkspaceWorktree(
+                from: rootProjectPath,
+                branch: pending.branch,
+                createBranch: pending.createBranch,
+                baseBranch: pending.baseBranch,
+                autoOpen: false,
+                targetPath: pending.worktreePath
+            )
+            return
+        }
+
         guard let worktree = snapshot.projects.first(where: { $0.path == rootProjectPath })?.worktrees.first(where: {
-            normalizePathForCompare($0.path) == normalizePathForCompare(worktreePath)
+            normalizePathForCompare($0.path) == normalizedWorktreePath
         }) else {
             throw NativeWorktreeError.invalidPath("worktree 不存在或已移除")
         }
@@ -2285,16 +2371,39 @@ public final class NativeAppViewModel {
     }
 
     public func deleteWorkspaceWorktree(_ worktreePath: String, from rootProjectPath: String) async throws {
+        let normalizedWorktreePath = normalizePathForCompare(worktreePath)
+        if let pending = pendingWorkspaceWorktreeCreatesByPath[normalizedWorktreePath] {
+            guard pending.status != .creating else {
+                throw NativeWorktreeError.operationInProgress("该 worktree 正在创建中，无法删除")
+            }
+            pendingWorkspaceWorktreeCreatesByPath.removeValue(forKey: normalizedWorktreePath)
+            let cleanupWarning = cleanupFailedWorkspaceWorktreeCreate(
+                WorktreeCreateContext(
+                    request: NativeWorktreeCreateRequest(
+                        sourceProjectPath: pending.rootProjectPath,
+                        branch: pending.branch,
+                        createBranch: pending.createBranch,
+                        baseBranch: pending.baseBranch,
+                        targetPath: pending.worktreePath
+                    ),
+                    rootProjectPath: pending.rootProjectPath,
+                    previewPath: pending.worktreePath
+                )
+            )
+            try? await refreshProjectWorktrees(rootProjectPath)
+            if let cleanupWarning, !cleanupWarning.isEmpty {
+                errorMessage = cleanupWarning
+            }
+            return
+        }
+
         guard let projectIndex = snapshot.projects.firstIndex(where: { $0.path == rootProjectPath }) else {
             throw NativeWorktreeError.invalidProject("项目不存在或已移除")
         }
         guard let worktree = snapshot.projects[projectIndex].worktrees.first(where: {
-            normalizePathForCompare($0.path) == normalizePathForCompare(worktreePath)
+            normalizePathForCompare($0.path) == normalizedWorktreePath
         }) else {
             throw NativeWorktreeError.invalidPath("worktree 不存在或已移除")
-        }
-        if worktree.status == "creating" {
-            throw NativeWorktreeError.operationInProgress("该 worktree 正在创建中，无法删除")
         }
 
         let result = try await Task.detached(priority: .userInitiated) {
@@ -2315,6 +2424,46 @@ public final class NativeAppViewModel {
         if let warning = result.warning, !warning.isEmpty {
             errorMessage = warning
         }
+    }
+
+    public func workspaceWorktreeDeletePresentation(
+        for worktreePath: String,
+        from rootProjectPath: String
+    ) -> WorkspaceWorktreeDeletePresentation? {
+        let normalizedWorktreePath = normalizePathForCompare(worktreePath)
+        if let pending = pendingWorkspaceWorktreeCreatesByPath[normalizedWorktreePath],
+           normalizePathForCompare(pending.rootProjectPath) == normalizePathForCompare(rootProjectPath),
+           pending.status != .creating {
+            return WorkspaceWorktreeDeletePresentation(
+                rootProjectPath: rootProjectPath,
+                worktreePath: worktreePath,
+                title: "清除失败记录",
+                actionTitle: "清除记录",
+                message: "将清除这条失败的 worktree 创建记录，并尝试删除残留目录、分支与 Git metadata。不会删除任何已成功创建的 worktree。",
+                kind: .clearFailedCreation
+            )
+        }
+
+        guard let project = snapshot.projects.first(where: {
+            normalizePathForCompare($0.path) == normalizePathForCompare(rootProjectPath)
+        }) else {
+            return nil
+        }
+        guard let worktree = project.worktrees.first(where: {
+            normalizePathForCompare($0.path) == normalizedWorktreePath
+        }) else {
+            return nil
+        }
+        return WorkspaceWorktreeDeletePresentation(
+            rootProjectPath: rootProjectPath,
+            worktreePath: worktreePath,
+            title: "删除 worktree",
+            actionTitle: "删除",
+            message: (worktree.baseBranch?.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty == false)
+                ? "将删除 \(worktreePath)，并丢弃其中未提交修改与未跟踪文件。该 worktree 的本地分支也会一并删除；若分支包含未合并提交，DevHaven 会强制删除它。"
+                : "将删除 \(worktreePath)，并丢弃其中未提交修改与未跟踪文件。",
+            kind: .deletePersistedWorktree
+        )
     }
 
     public func closeDetailPanel() {
@@ -3040,15 +3189,30 @@ public final class NativeAppViewModel {
                 return nil
             }
 
+            let normalizedProjectPath = normalizePathForCompare(sessionSnapshot.projectPath)
+            let normalizedRootProjectPath = normalizePathForCompare(sessionSnapshot.rootProjectPath)
+            let normalizedSessionSnapshot = ProjectWorkspaceRestoreSnapshot(
+                projectPath: normalizedProjectPath,
+                rootProjectPath: normalizedRootProjectPath,
+                isQuickTerminal: sessionSnapshot.isQuickTerminal,
+                workspaceRootContext: sessionSnapshot.workspaceRootContext,
+                workspaceAlignmentGroupID: sessionSnapshot.workspaceAlignmentGroupID,
+                workspaceId: sessionSnapshot.workspaceId,
+                selectedTabId: sessionSnapshot.selectedTabId,
+                nextTabNumber: sessionSnapshot.nextTabNumber,
+                nextPaneNumber: sessionSnapshot.nextPaneNumber,
+                tabs: sessionSnapshot.tabs
+            )
+
             let controller = GhosttyWorkspaceController(
-                projectPath: sessionSnapshot.projectPath,
+                projectPath: normalizedProjectPath,
                 workspaceId: sessionSnapshot.workspaceId
             )
-            controller.restore(from: sessionSnapshot)
+            controller.restore(from: normalizedSessionSnapshot)
             registerWorkspaceRestoreObserver(for: controller)
 
-            if sessionSnapshot.projectPath == sessionSnapshot.rootProjectPath, !sessionSnapshot.isQuickTerminal {
-                refreshCurrentBranch(for: sessionSnapshot.projectPath)
+            if normalizedProjectPath == normalizedRootProjectPath, !sessionSnapshot.isQuickTerminal {
+                refreshCurrentBranch(for: normalizedProjectPath)
             }
 
             let restoredWorkspaceRootContext = sessionSnapshot.workspaceRootContext.flatMap { context in
@@ -3059,8 +3223,8 @@ public final class NativeAppViewModel {
             }
 
             return OpenWorkspaceSessionState(
-                projectPath: sessionSnapshot.projectPath,
-                rootProjectPath: sessionSnapshot.rootProjectPath,
+                projectPath: normalizedProjectPath,
+                rootProjectPath: normalizedRootProjectPath,
                 controller: controller,
                 isQuickTerminal: sessionSnapshot.isQuickTerminal,
                 workspaceRootContext: restoredWorkspaceRootContext,
@@ -3076,15 +3240,15 @@ public final class NativeAppViewModel {
         syncAttentionStateWithOpenSessions()
 
         let restoredActiveProjectPath = restoredSnapshot.activeProjectPath.flatMap { candidate in
-            openWorkspaceProjectPaths.contains(candidate) ? candidate : nil
+            canonicalWorkspaceSessionPath(for: candidate, in: restoredSessions)
         } ?? restoredSessions.last?.projectPath
 
         activeWorkspaceProjectPath = restoredActiveProjectPath
         selectedProjectPath = restoredSnapshot.selectedProjectPath.flatMap { candidate in
-            if openWorkspaceProjectPaths.contains(candidate) {
-                return candidate
+            if let workspaceSessionPath = canonicalWorkspaceSessionPath(for: candidate, in: restoredSessions) {
+                return workspaceSessionPath
             }
-            return resolveDisplayProject(for: candidate) == nil ? nil : candidate
+            return resolveDisplayProject(for: candidate)?.path
         } ?? restoredActiveProjectPath ?? selectedProjectPath
 
         if let restoredActiveProjectPath,
@@ -3133,23 +3297,26 @@ public final class NativeAppViewModel {
         workspaceRootContext: WorkspaceRootSessionContext? = nil,
         workspaceAlignmentGroupID: String? = nil
     ) {
-        guard workspaceSessionIndex(for: path) == nil else {
+        let normalizedPath = normalizePathForCompare(path)
+        let normalizedRootProjectPath = normalizePathForCompare(rootProjectPath)
+
+        guard workspaceSessionIndex(for: normalizedPath) == nil else {
             return
         }
-        let controller = GhosttyWorkspaceController(projectPath: path)
+        let controller = GhosttyWorkspaceController(projectPath: normalizedPath)
         registerWorkspaceRestoreObserver(for: controller)
         openWorkspaceSessions.append(
             OpenWorkspaceSessionState(
-                projectPath: path,
-                rootProjectPath: rootProjectPath,
+                projectPath: normalizedPath,
+                rootProjectPath: normalizedRootProjectPath,
                 controller: controller,
                 isQuickTerminal: isQuickTerminal,
                 workspaceRootContext: workspaceRootContext,
                 workspaceAlignmentGroupID: workspaceAlignmentGroupID
             )
         )
-        if path == rootProjectPath, !isQuickTerminal {
-            refreshCurrentBranch(for: path)
+        if normalizedPath == normalizedRootProjectPath, !isQuickTerminal {
+            refreshCurrentBranch(for: normalizedPath)
         }
     }
 
@@ -3172,11 +3339,34 @@ public final class NativeAppViewModel {
         })
     }
 
+    private func workspaceSession(for path: String?) -> OpenWorkspaceSessionState? {
+        guard let path else {
+            return nil
+        }
+        let normalizedPath = normalizePathForCompare(path)
+        return openWorkspaceSessions.first(where: {
+            normalizePathForCompare($0.projectPath) == normalizedPath
+        })
+    }
+
+    private func canonicalWorkspaceSessionPath(
+        for path: String?,
+        in sessions: [OpenWorkspaceSessionState]? = nil
+    ) -> String? {
+        guard let path else {
+            return nil
+        }
+        let normalizedPath = normalizePathForCompare(path)
+        return (sessions ?? openWorkspaceSessions).first(where: {
+            normalizePathForCompare($0.projectPath) == normalizedPath
+        })?.projectPath
+    }
+
     private func promoteWorkspaceSessionIfNeeded(for path: String, rootProjectPath: String) {
         guard let index = workspaceSessionIndex(for: path) else {
             return
         }
-        openWorkspaceSessions[index].rootProjectPath = rootProjectPath
+        openWorkspaceSessions[index].rootProjectPath = normalizePathForCompare(rootProjectPath)
         openWorkspaceSessions[index].workspaceAlignmentGroupID = nil
     }
 
@@ -3203,7 +3393,7 @@ public final class NativeAppViewModel {
     }
 
     private func isQuickTerminalSessionPath(_ path: String) -> Bool {
-        openWorkspaceSessions.first(where: { $0.projectPath == path })?.isQuickTerminal ?? false
+        workspaceSession(for: path)?.isQuickTerminal ?? false
     }
 
     private func resolvedWorkspacePresentedTabSelection(for projectPath: String) -> WorkspacePresentedTabSelection? {
@@ -3656,11 +3846,7 @@ public final class NativeAppViewModel {
     }
 
     private func workspaceController(for projectPath: String? = nil) -> GhosttyWorkspaceController? {
-        let targetProjectPath = projectPath ?? activeWorkspaceProjectPath
-        guard let targetProjectPath else {
-            return nil
-        }
-        return openWorkspaceSessions.first(where: { $0.projectPath == targetProjectPath })?.controller
+        workspaceSession(for: projectPath ?? activeWorkspaceProjectPath)?.controller
     }
 
     private func makeProjectRunConfiguration(
@@ -3877,8 +4063,19 @@ public final class NativeAppViewModel {
     private func syncProjectRepositoryState(
         rootProjectPath: String,
         gitWorktrees: [NativeGitWorktree],
-        currentBranch: String
+        currentBranch: String?
     ) throws {
+        let gitWorktreePaths = Set(gitWorktrees.map { normalizePathForCompare($0.path) })
+        let stalePendingPaths = pendingWorkspaceWorktreeCreatesByPath.keys.filter { gitWorktreePaths.contains($0) }
+        let promotedPendingWorktrees = stalePendingPaths.compactMap { path in
+            pendingWorkspaceWorktreeCreatesByPath[path].map(makePromotedPendingWorktree)
+        }
+        if !stalePendingPaths.isEmpty {
+            for path in stalePendingPaths {
+                pendingWorkspaceWorktreeCreatesByPath.removeValue(forKey: path)
+            }
+        }
+
         if let projectIndex = snapshot.projects.firstIndex(where: {
             normalizePathForCompare($0.path) == rootProjectPath
         }) {
@@ -3887,7 +4084,8 @@ public final class NativeAppViewModel {
             let nextWorktrees = buildSyncedWorktrees(
                 existingWorktrees: snapshot.projects[projectIndex].worktrees,
                 gitWorktrees: gitWorktrees,
-                preservedLiveWorktrees: preservedOpenedWorktrees
+                preservedLiveWorktrees: preservedOpenedWorktrees,
+                promotedPendingWorktrees: promotedPendingWorktrees
             )
 
             if snapshot.projects[projectIndex].worktrees != nextWorktrees {
@@ -3896,13 +4094,13 @@ public final class NativeAppViewModel {
                 try persistProjects(projects)
             }
 
-            if currentBranchByProjectPath[storedRootProjectPath] != currentBranch {
+            if let currentBranch, currentBranchByProjectPath[storedRootProjectPath] != currentBranch {
                 currentBranchByProjectPath[storedRootProjectPath] = currentBranch
             }
             return
         }
 
-        if currentBranchByProjectPath[rootProjectPath] != currentBranch {
+        if let currentBranch, currentBranchByProjectPath[rootProjectPath] != currentBranch {
             currentBranchByProjectPath[rootProjectPath] = currentBranch
         }
     }
@@ -4245,7 +4443,8 @@ public final class NativeAppViewModel {
         showsInAppNotifications: Bool,
         moveNotifiedWorktreeToTop: Bool
     ) -> [WorkspaceSidebarWorktreeItem] {
-        let items = rootProject.worktrees.map { worktree -> WorkspaceSidebarWorktreeItem in
+        let persistedPaths = Set(rootProject.worktrees.map { normalizePathForCompare($0.path) })
+        let persistedItems = rootProject.worktrees.map { worktree -> WorkspaceSidebarWorktreeItem in
             let owningProjectPoolSession = openWorkspaceSessions.first(where: {
                 normalizePathForCompare($0.projectPath) == normalizePathForCompare(worktree.path) &&
                     isWorkspaceSessionOwnedByProjectPool($0, rootProjectPath: rootProjectPath)
@@ -4270,6 +4469,41 @@ public final class NativeAppViewModel {
                 )
             )
         }
+        let pendingItems = pendingWorkspaceWorktreeCreatesByPath.values
+            .filter { normalizePathForCompare($0.rootProjectPath) == normalizePathForCompare(rootProjectPath) }
+            .filter { !persistedPaths.contains(normalizePathForCompare($0.worktreePath)) }
+            .sorted { $0.worktreePath < $1.worktreePath }
+            .map { pending -> WorkspaceSidebarWorktreeItem in
+                let syntheticWorktree = ProjectWorktree(
+                    id: createWorktreeProjectID(path: pending.worktreePath),
+                    name: resolveWorktreeName(pending.worktreePath),
+                    path: pending.worktreePath,
+                    branch: pending.branch,
+                    baseBranch: pending.baseBranch,
+                    inheritConfig: true,
+                    created: pending.createdAt,
+                    updatedAt: pending.createdAt
+                )
+                return WorkspaceSidebarWorktreeItem(
+                    rootProjectPath: rootProjectPath,
+                    worktree: syntheticWorktree,
+                    isOpen: false,
+                    isActive: false,
+                    notifications: [],
+                    unreadNotificationCount: 0,
+                    taskStatus: nil,
+                    agentState: nil,
+                    agentSummary: nil,
+                    agentKind: nil,
+                    displayStateOverride: pending.status == .creating
+                        ? .creating(message: pending.message)
+                        : .failed(message: pending.error ?? pending.message),
+                    displayInitStepOverride: pending.step,
+                    displayInitErrorOverride: pending.error,
+                    displayInitMessageOverride: pending.message
+                )
+            }
+        let items = persistedItems + pendingItems
         guard moveNotifiedWorktreeToTop, showsInAppNotifications else {
             return items
         }
@@ -4520,31 +4754,24 @@ public final class NativeAppViewModel {
     }
 
     private func applyWorktreeProgress(_ progress: NativeWorktreeProgress, rootProjectPath: String) {
-        guard let projectIndex = snapshot.projects.firstIndex(where: { $0.path == rootProjectPath }) else {
+        let normalizedWorktreePath = normalizePathForCompare(progress.worktreePath)
+        guard var pending = pendingWorkspaceWorktreeCreatesByPath[normalizedWorktreePath] else {
             return
         }
-        let now = swiftDateFromDate(Date())
-        let current = snapshot.projects[projectIndex].worktrees.first(where: {
-            normalizePathForCompare($0.path) == normalizePathForCompare(progress.worktreePath)
-        })
-        let nextWorktree = ProjectWorktree(
-            id: current?.id ?? createWorktreeProjectID(path: progress.worktreePath),
-            name: current?.name ?? resolveWorktreeName(progress.worktreePath),
-            path: progress.worktreePath,
+        pending = PendingWorkspaceWorktreeCreateState(
+            rootProjectPath: pending.rootProjectPath,
             branch: progress.branch,
-            baseBranch: current?.baseBranch ?? progress.baseBranch,
-            inheritConfig: current?.inheritConfig ?? true,
-            created: current?.created ?? now,
-            status: progress.step == .ready ? "ready" : progress.step == .failed ? "failed" : "creating",
-            initStep: progress.step.rawValue,
-            initMessage: progress.message,
-            initError: progress.error,
-            initJobId: current?.initJobId,
-            updatedAt: now
+            baseBranch: pending.baseBranch ?? progress.baseBranch,
+            worktreePath: pending.worktreePath,
+            createBranch: pending.createBranch,
+            jobID: pending.jobID,
+            createdAt: pending.createdAt,
+            status: progress.step == .failed ? .failed : .creating,
+            step: progress.step,
+            message: progress.message,
+            error: progress.error
         )
-        var projects = snapshot.projects
-        upsertWorktree(&projects[projectIndex].worktrees, worktree: nextWorktree)
-        try? persistProjects(projects)
+        pendingWorkspaceWorktreeCreatesByPath[normalizedWorktreePath] = pending
         worktreeInteractionState = WorktreeInteractionState(
             rootProjectPath: rootProjectPath,
             branch: progress.branch,
@@ -4558,73 +4785,112 @@ public final class NativeAppViewModel {
     private func finishCreateWorkspaceWorktree(
         _ result: NativeWorktreeCreateResult,
         rootProjectPath: String,
+        bootstrapResult: NativeWorktreeEnvironmentResult,
         autoOpen: Bool
     ) {
-        guard let projectIndex = snapshot.projects.firstIndex(where: { $0.path == rootProjectPath }) else {
-            worktreeInteractionState = nil
-            return
-        }
-
-        let now = swiftDateFromDate(Date())
-        let current = snapshot.projects[projectIndex].worktrees.first(where: {
-            normalizePathForCompare($0.path) == normalizePathForCompare(result.worktreePath)
-        })
-        let readyWorktree = ProjectWorktree(
-            id: current?.id ?? createWorktreeProjectID(path: result.worktreePath),
-            name: current?.name ?? resolveWorktreeName(result.worktreePath),
-            path: result.worktreePath,
-            branch: result.branch,
-            baseBranch: current?.baseBranch ?? result.baseBranch,
-            inheritConfig: current?.inheritConfig ?? true,
-            created: current?.created ?? now,
-            status: "ready",
-            initStep: NativeWorktreeInitStep.ready.rawValue,
-            initMessage: result.warning == nil ? "创建完成" : "创建完成（环境初始化存在告警）",
-            initError: result.warning,
-            initJobId: current?.initJobId,
-            updatedAt: now
-        )
-        var projects = snapshot.projects
-        upsertWorktree(&projects[projectIndex].worktrees, worktree: readyWorktree)
-        try? persistProjects(projects)
+        pendingWorkspaceWorktreeCreatesByPath.removeValue(forKey: normalizePathForCompare(result.worktreePath))
         worktreeInteractionState = nil
 
         if autoOpen {
             openWorkspaceWorktree(result.worktreePath, from: rootProjectPath)
         }
-        if let warning = result.warning, !warning.isEmpty {
+        let warning = [result.warning, formatWorktreeEnvironmentWarning(bootstrapResult)]
+            .compactMap { value -> String? in
+                guard let value, !value.isEmpty else { return nil }
+                return value
+            }
+            .joined(separator: "\n\n")
+        if !warning.isEmpty {
             errorMessage = warning
         }
     }
 
     private func markWorktreeAsFailed(worktreePath: String, rootProjectPath: String, errorMessage: String) {
-        guard let projectIndex = snapshot.projects.firstIndex(where: { $0.path == rootProjectPath }) else {
+        let normalizedWorktreePath = normalizePathForCompare(worktreePath)
+        guard var pending = pendingWorkspaceWorktreeCreatesByPath[normalizedWorktreePath] else {
             return
         }
-        let now = swiftDateFromDate(Date())
-        guard let current = snapshot.projects[projectIndex].worktrees.first(where: {
-            normalizePathForCompare($0.path) == normalizePathForCompare(worktreePath)
-        }) else {
-            return
-        }
-        let failedWorktree = ProjectWorktree(
-            id: current.id,
-            name: current.name,
-            path: current.path,
-            branch: current.branch,
-            baseBranch: current.baseBranch,
-            inheritConfig: current.inheritConfig,
-            created: current.created,
-            status: "failed",
-            initStep: NativeWorktreeInitStep.failed.rawValue,
-            initMessage: errorMessage,
-            initError: errorMessage,
-            initJobId: current.initJobId,
-            updatedAt: now
+        pending = PendingWorkspaceWorktreeCreateState(
+            rootProjectPath: pending.rootProjectPath,
+            branch: pending.branch,
+            baseBranch: pending.baseBranch,
+            worktreePath: pending.worktreePath,
+            createBranch: pending.createBranch,
+            jobID: pending.jobID,
+            createdAt: pending.createdAt,
+            status: .failed,
+            step: .failed,
+            message: errorMessage,
+            error: errorMessage
         )
-        var projects = snapshot.projects
-        upsertWorktree(&projects[projectIndex].worktrees, worktree: failedWorktree)
-        try? persistProjects(projects)
+        pendingWorkspaceWorktreeCreatesByPath[normalizedWorktreePath] = pending
+    }
+
+    private func cleanupFailedWorkspaceWorktreeCreate(_ context: WorktreeCreateContext) -> String? {
+        do {
+            let cleanup = try worktreeService.cleanupFailedWorktreeCreate(
+                NativeWorktreeCleanupRequest(
+                    sourceProjectPath: context.rootProjectPath,
+                    worktreePath: context.previewPath,
+                    branch: context.request.branch,
+                    shouldDeleteCreatedBranch: context.request.createBranch
+                )
+            )
+            return cleanup.warning
+        } catch {
+            return error.localizedDescription
+        }
+    }
+
+    private func formatWorktreeEnvironmentWarning(_ result: NativeWorktreeEnvironmentResult) -> String? {
+        guard let warning = result.warning?.trimmingCharacters(in: .whitespacesAndNewlines),
+              !warning.isEmpty else {
+            return nil
+        }
+
+        var sections = [warning]
+        if let failedCommand = result.failedCommand?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !failedCommand.isEmpty {
+            sections.append("失败命令：\n$ \(failedCommand)")
+        }
+        let latestOutputLines = result.latestOutputLines
+            .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty }
+        if !latestOutputLines.isEmpty {
+            sections.append("最近输出：\n" + latestOutputLines.joined(separator: "\n"))
+        }
+        return sections.joined(separator: "\n\n")
+    }
+
+    private func prepareWorkspaceWorktreeEnvironment(_ context: WorktreeCreateContext) async -> NativeWorktreeEnvironmentResult {
+        let normalizedWorktreePath = normalizePathForCompare(context.previewPath)
+        if var pending = pendingWorkspaceWorktreeCreatesByPath[normalizedWorktreePath] {
+            pending.status = .creating
+            pending.step = .preparingEnvironment
+            pending.message = "执行中：准备工作区环境..."
+            pending.error = nil
+            pendingWorkspaceWorktreeCreatesByPath[normalizedWorktreePath] = pending
+            worktreeInteractionState = WorktreeInteractionState(
+                rootProjectPath: context.rootProjectPath,
+                branch: pending.branch,
+                baseBranch: pending.baseBranch,
+                worktreePath: pending.worktreePath,
+                step: .preparingEnvironment,
+                message: pending.message
+            )
+        }
+
+        let worktreeEnvironmentService = worktreeEnvironmentService
+        let rootProjectPath = context.rootProjectPath
+        let previewPath = context.previewPath
+        let workspaceName = context.request.branch.trimmingCharacters(in: .whitespacesAndNewlines)
+        return await Task.detached(priority: .userInitiated) {
+            worktreeEnvironmentService.prepareEnvironment(
+                mainRepositoryPath: rootProjectPath,
+                worktreePath: previewPath,
+                workspaceName: workspaceName
+            )
+        }.value
     }
 
     private func upsertWorktree(_ worktrees: inout [ProjectWorktree], worktree: ProjectWorktree) {
@@ -4634,6 +4900,19 @@ public final class NativeAppViewModel {
             worktrees.append(worktree)
             worktrees.sort { $0.path < $1.path }
         }
+    }
+
+    private func makePromotedPendingWorktree(_ pending: PendingWorkspaceWorktreeCreateState) -> ProjectWorktree {
+        ProjectWorktree(
+            id: createWorktreeProjectID(path: pending.worktreePath),
+            name: resolveWorktreeName(pending.worktreePath),
+            path: pending.worktreePath,
+            branch: pending.branch,
+            baseBranch: pending.baseBranch,
+            inheritConfig: true,
+            created: pending.createdAt,
+            updatedAt: pending.createdAt
+        )
     }
 }
 
@@ -5028,11 +5307,6 @@ private func buildReadyWorktree(path: String, branch: String, now: SwiftDate) ->
         branch: branch,
         inheritConfig: true,
         created: now,
-        status: "ready",
-        initStep: NativeWorktreeInitStep.ready.rawValue,
-        initMessage: "已添加现有 worktree",
-        initError: nil,
-        initJobId: nil,
         updatedAt: now
     )
 }
@@ -5064,13 +5338,18 @@ private func buildWorktreeVirtualProject(sourceProject: Project, worktree: Proje
 private func buildSyncedWorktrees(
     existingWorktrees: [ProjectWorktree],
     gitWorktrees: [NativeGitWorktree],
-    preservedLiveWorktrees: [ProjectWorktree] = []
+    preservedLiveWorktrees: [ProjectWorktree] = [],
+    promotedPendingWorktrees: [ProjectWorktree] = []
 ) -> [ProjectWorktree] {
     let existingByPath = Dictionary(uniqueKeysWithValues: existingWorktrees.map { (normalizePathForCompare($0.path), $0) })
+    let promotedPendingByPath = Dictionary(uniqueKeysWithValues: promotedPendingWorktrees.map {
+        (normalizePathForCompare($0.path), $0)
+    })
     let now = swiftDateFromDate(Date())
     var mergedWorktrees = gitWorktrees
         .map { item -> ProjectWorktree in
-            let existing = existingByPath[normalizePathForCompare(item.path)]
+            let normalizedPath = normalizePathForCompare(item.path)
+            let existing = existingByPath[normalizedPath] ?? promotedPendingByPath[normalizedPath]
             return ProjectWorktree(
                 id: existing?.id ?? createWorktreeProjectID(path: item.path),
                 name: existing?.name ?? resolveWorktreeName(item.path),
@@ -5079,18 +5358,24 @@ private func buildSyncedWorktrees(
                 baseBranch: existing?.baseBranch,
                 inheritConfig: existing?.inheritConfig ?? true,
                 created: existing?.created ?? now,
-                status: existing?.status,
-                initStep: existing?.initStep,
-                initMessage: existing?.initMessage,
-                initError: existing?.initError,
-                initJobId: existing?.initJobId,
                 updatedAt: existing?.updatedAt
             )
         }
     for worktree in preservedLiveWorktrees where !mergedWorktrees.contains(where: {
         normalizePathForCompare($0.path) == normalizePathForCompare(worktree.path)
     }) {
-        mergedWorktrees.append(worktree)
+        mergedWorktrees.append(
+            ProjectWorktree(
+                id: worktree.id,
+                name: worktree.name,
+                path: worktree.path,
+                branch: worktree.branch,
+                baseBranch: worktree.baseBranch,
+                inheritConfig: worktree.inheritConfig,
+                created: worktree.created,
+                updatedAt: worktree.updatedAt
+            )
+        )
     }
     return mergedWorktrees.sorted { $0.path < $1.path }
 }

--- a/macos/Tests/DevHavenCoreTests/NativeAppViewModelWorktreeCreationTests.swift
+++ b/macos/Tests/DevHavenCoreTests/NativeAppViewModelWorktreeCreationTests.swift
@@ -1,0 +1,820 @@
+import XCTest
+@testable import DevHavenCore
+
+@MainActor
+final class NativeAppViewModelWorktreeCreationTests: XCTestCase {
+    func testCreateWorkspaceWorktreeFailureCleansResidualBranchAndDirectory() async throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.initializeRepository(defaultBranch: "main")
+        try fixture.commit(fileName: "README.md", content: "hello")
+
+        let viewModel = fixture.makeViewModel()
+        viewModel.snapshot = NativeAppSnapshot(
+            appState: AppStateFile(),
+            projects: [fixture.makeProject()]
+        )
+
+        let branch = "feature/payment"
+        let targetPath = try viewModel.managedWorktreePathPreview(for: fixture.repositoryURL.path, branch: branch)
+        let targetURL = URL(fileURLWithPath: targetPath, isDirectory: true)
+        try FileManager.default.createDirectory(at: targetURL, withIntermediateDirectories: true)
+        try "stale".write(
+            to: targetURL.appendingPathComponent("stale.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        do {
+            try await viewModel.createWorkspaceWorktree(
+                from: fixture.repositoryURL.path,
+                branch: branch,
+                createBranch: true,
+                baseBranch: "main",
+                autoOpen: false,
+                targetPath: targetPath
+            )
+            XCTFail("预期创建失败，但实际成功")
+        } catch {
+            // 预期失败：关键是验证失败后的 cleanup 是否生效。
+        }
+
+        let localBranch = try fixture.git(in: fixture.repositoryURL, ["branch", "--list", branch])
+        XCTAssertTrue(localBranch.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        XCTAssertFalse(FileManager.default.fileExists(atPath: targetPath))
+        XCTAssertEqual(viewModel.snapshot.projects.first?.worktrees.map(\.path) ?? [], [])
+    }
+
+    func testCurrentBranchFallsBackToSymbolicRefForUnbornHead() throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.initializeRepository(defaultBranch: "develop")
+
+        let service = NativeGitWorktreeService(homeDirectoryURL: fixture.homeURL)
+        let branch = try service.currentBranch(at: fixture.repositoryURL.path)
+        XCTAssertEqual(branch, "develop")
+    }
+
+    func testRefreshProjectWorktreesDoesNotFailForUnbornHead() async throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.initializeRepository(defaultBranch: "main")
+
+        let viewModel = fixture.makeViewModel()
+        viewModel.snapshot = NativeAppSnapshot(
+            appState: AppStateFile(),
+            projects: [fixture.makeProject()]
+        )
+
+        try await viewModel.refreshProjectWorktrees(fixture.repositoryURL.path)
+
+        XCTAssertEqual(viewModel.snapshot.projects.first?.worktrees.count, 0)
+    }
+
+    func testCreateWorkspaceWorktreeSuccessPersistsRealWorktreeWithoutTransientStatus() async throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.initializeRepository(defaultBranch: "main")
+        try fixture.commit(fileName: "README.md", content: "hello")
+
+        let viewModel = fixture.makeViewModel()
+        viewModel.snapshot = NativeAppSnapshot(
+            appState: AppStateFile(),
+            projects: [fixture.makeProject()]
+        )
+
+        try await viewModel.createWorkspaceWorktree(
+            from: fixture.repositoryURL.path,
+            branch: "feature/success",
+            createBranch: true,
+            baseBranch: "main",
+            autoOpen: false
+        )
+
+        let worktree = try XCTUnwrap(viewModel.snapshot.projects.first?.worktrees.first)
+        XCTAssertEqual(worktree.branch, "feature/success")
+        XCTAssertEqual(worktree.baseBranch, "main")
+        XCTAssertNil(worktree.status)
+        XCTAssertNil(worktree.initStep)
+        XCTAssertNil(worktree.initMessage)
+        XCTAssertNil(worktree.initError)
+    }
+
+    func testDeleteWorkspaceWorktreeRemovesCreatedLocalBranch() async throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.initializeRepository(defaultBranch: "main")
+        try fixture.commit(fileName: "README.md", content: "hello")
+
+        let viewModel = fixture.makeViewModel()
+        viewModel.snapshot = NativeAppSnapshot(
+            appState: AppStateFile(),
+            projects: [fixture.makeProject()]
+        )
+
+        try await viewModel.createWorkspaceWorktree(
+            from: fixture.repositoryURL.path,
+            branch: "feature/delete-branch",
+            createBranch: true,
+            baseBranch: "main",
+            autoOpen: false
+        )
+
+        let worktreePath = try XCTUnwrap(viewModel.snapshot.projects.first?.worktrees.first?.path)
+        try await viewModel.deleteWorkspaceWorktree(worktreePath, from: fixture.repositoryURL.path)
+
+        let localBranch = try fixture.git(in: fixture.repositoryURL, ["branch", "--list", "feature/delete-branch"])
+        XCTAssertTrue(localBranch.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    func testDeleteWorkspaceWorktreeForceRemovesCreatedBranchWithUnmergedCommit() async throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.initializeRepository(defaultBranch: "main")
+        try fixture.commit(fileName: "README.md", content: "hello")
+
+        let viewModel = fixture.makeViewModel()
+        viewModel.snapshot = NativeAppSnapshot(
+            appState: AppStateFile(),
+            projects: [fixture.makeProject()]
+        )
+
+        try await viewModel.createWorkspaceWorktree(
+            from: fixture.repositoryURL.path,
+            branch: "feature/delete-branch-with-commit",
+            createBranch: true,
+            baseBranch: "main",
+            autoOpen: false
+        )
+
+        let worktreePath = try XCTUnwrap(viewModel.snapshot.projects.first?.worktrees.first?.path)
+        let worktreeURL = URL(fileURLWithPath: worktreePath, isDirectory: true)
+        let fileURL = worktreeURL.appendingPathComponent("feature.txt")
+        try "feature".write(to: fileURL, atomically: true, encoding: .utf8)
+        try fixture.git(in: worktreeURL, ["add", "feature.txt"])
+        try fixture.git(in: worktreeURL, ["commit", "-m", "feature work"])
+
+        try await viewModel.deleteWorkspaceWorktree(worktreePath, from: fixture.repositoryURL.path)
+
+        let localBranch = try fixture.git(in: fixture.repositoryURL, ["branch", "--list", "feature/delete-branch-with-commit"])
+        XCTAssertTrue(localBranch.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+    }
+
+    func testCreateWorkspaceWorktreePreservesBaseBranchMetadataForLaterDelete() async throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.initializeRepository(defaultBranch: "main")
+        try fixture.commit(fileName: "README.md", content: "hello")
+
+        let viewModel = fixture.makeViewModel()
+        viewModel.snapshot = NativeAppSnapshot(
+            appState: AppStateFile(),
+            projects: [fixture.makeProject()]
+        )
+
+        try await viewModel.createWorkspaceWorktree(
+            from: fixture.repositoryURL.path,
+            branch: "feature/preserve-base-branch",
+            createBranch: true,
+            baseBranch: "main",
+            autoOpen: false
+        )
+
+        let worktree = try XCTUnwrap(viewModel.snapshot.projects.first?.worktrees.first)
+        XCTAssertEqual(worktree.branch, "feature/preserve-base-branch")
+        XCTAssertEqual(worktree.baseBranch, "main")
+    }
+
+    func testCreateWorkspaceWorktreeRejectsInvalidBranchName() async throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.initializeRepository(defaultBranch: "main")
+        try fixture.commit(fileName: "README.md", content: "hello")
+
+        let viewModel = fixture.makeViewModel()
+        viewModel.snapshot = NativeAppSnapshot(
+            appState: AppStateFile(),
+            projects: [fixture.makeProject()]
+        )
+
+        do {
+            try await viewModel.createWorkspaceWorktree(
+                from: fixture.repositoryURL.path,
+                branch: "bad branch",
+                createBranch: true,
+                baseBranch: "main",
+                autoOpen: false
+            )
+            XCTFail("预期非法分支名被拒绝，但实际成功")
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            XCTAssertTrue(message.contains("分支名"), "错误文案应提示分支名非法，实际：\(message)")
+        }
+
+        XCTAssertEqual(viewModel.snapshot.projects.first?.worktrees.count, 0)
+        let previewPath = try viewModel.managedWorktreePathPreview(for: fixture.repositoryURL.path, branch: "bad branch")
+        XCTAssertNil(
+            viewModel.workspaceWorktreeDeletePresentation(for: previewPath, from: fixture.repositoryURL.path),
+            "非法分支名不应留下 pending failed 记录"
+        )
+    }
+
+    func testCreateWorkspaceWorktreeBootstrapWarningDoesNotFailRealWorktreeCreation() async throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.initializeRepository(defaultBranch: "main")
+        try fixture.commit(fileName: "README.md", content: "hello")
+
+        let viewModel = fixture.makeViewModel(
+            worktreeEnvironmentService: StubWorktreeEnvironmentService(
+                result: NativeWorktreeEnvironmentResult(
+                    warning: "bootstrap warning"
+                )
+            )
+        )
+        viewModel.snapshot = NativeAppSnapshot(
+            appState: AppStateFile(),
+            projects: [fixture.makeProject()]
+        )
+
+        try await viewModel.createWorkspaceWorktree(
+            from: fixture.repositoryURL.path,
+            branch: "feature/bootstrap-warning",
+            createBranch: true,
+            baseBranch: "main",
+            autoOpen: false
+        )
+
+        let worktree = try XCTUnwrap(viewModel.snapshot.projects.first?.worktrees.first)
+        XCTAssertEqual(worktree.branch, "feature/bootstrap-warning")
+        XCTAssertEqual(viewModel.errorMessage, "bootstrap warning")
+    }
+
+    func testCreateWorkspaceWorktreeBootstrapWarningIncludesFailureContext() async throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.initializeRepository(defaultBranch: "main")
+        try fixture.commit(fileName: "README.md", content: "hello")
+
+        let viewModel = fixture.makeViewModel(
+            worktreeEnvironmentService: StubWorktreeEnvironmentService(
+                result: NativeWorktreeEnvironmentResult(
+                    warning: "bootstrap warning",
+                    executedCommands: ["pnpm install"],
+                    failedCommand: "pnpm install",
+                    latestOutputLines: [
+                        "stderr | permission denied",
+                        "stderr | retry with sudo"
+                    ]
+                )
+            )
+        )
+        viewModel.snapshot = NativeAppSnapshot(
+            appState: AppStateFile(),
+            projects: [fixture.makeProject()]
+        )
+
+        try await viewModel.createWorkspaceWorktree(
+            from: fixture.repositoryURL.path,
+            branch: "feature/bootstrap-warning-context",
+            createBranch: true,
+            baseBranch: "main",
+            autoOpen: false
+        )
+
+        let worktree = try XCTUnwrap(viewModel.snapshot.projects.first?.worktrees.first)
+        XCTAssertEqual(worktree.branch, "feature/bootstrap-warning-context")
+        let message = try XCTUnwrap(viewModel.errorMessage)
+        XCTAssertTrue(message.contains("bootstrap warning"))
+        XCTAssertTrue(message.contains("失败命令："))
+        XCTAssertTrue(message.contains("$ pnpm install"))
+        XCTAssertTrue(message.contains("permission denied"))
+        XCTAssertTrue(message.contains("retry with sudo"))
+    }
+
+    func testStartCreateWorkspaceWorktreeDefersOverlayUntilSheetCanDismiss() async throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        let previewPath = fixture.rootURL
+            .appendingPathComponent("managed/feature/deferred-overlay", isDirectory: true)
+            .path
+        let worktreeService = BlockingWorktreeService(
+            previewPath: previewPath,
+            defaultBranch: "main"
+        )
+        let viewModel = NativeAppViewModel(
+            store: LegacyCompatStore(homeDirectoryURL: fixture.homeURL),
+            worktreeService: worktreeService,
+            worktreeEnvironmentService: StubWorktreeEnvironmentService(result: NativeWorktreeEnvironmentResult())
+        )
+        viewModel.snapshot = NativeAppSnapshot(
+            appState: AppStateFile(),
+            projects: [fixture.makeProject()]
+        )
+
+        try viewModel.startCreateWorkspaceWorktree(
+            from: fixture.repositoryURL.path,
+            branch: "feature/deferred-overlay",
+            createBranch: true,
+            baseBranch: "main",
+            autoOpen: false
+        )
+
+        XCTAssertNil(
+            viewModel.worktreeInteractionState,
+            "startCreateWorkspaceWorktree 应先返回给 sheet，让弹窗先关闭，再显示全局进度面板"
+        )
+
+        for _ in 0..<20 where viewModel.worktreeInteractionState == nil {
+            await Task.yield()
+        }
+
+        XCTAssertNotNil(viewModel.worktreeInteractionState)
+        XCTAssertTrue(worktreeService.waitUntilCreateStarts())
+
+        worktreeService.finishCreate()
+        for _ in 0..<20 where viewModel.worktreeInteractionState != nil {
+            await Task.yield()
+        }
+
+        XCTAssertNil(viewModel.worktreeInteractionState)
+        XCTAssertEqual(viewModel.snapshot.projects.first?.worktrees.first?.path, previewPath)
+    }
+
+    func testWorkspaceWorktreeDeletePresentationUsesClearFailedCreationForPendingFailure() async throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.initializeRepository(defaultBranch: "main")
+        try fixture.commit(fileName: "README.md", content: "hello")
+
+        let viewModel = fixture.makeViewModel()
+        viewModel.snapshot = NativeAppSnapshot(
+            appState: AppStateFile(),
+            projects: [fixture.makeProject()]
+        )
+
+        let branch = "feature/delete-pending"
+        let targetPath = try viewModel.managedWorktreePathPreview(for: fixture.repositoryURL.path, branch: branch)
+        let targetURL = URL(fileURLWithPath: targetPath, isDirectory: true)
+        try FileManager.default.createDirectory(at: targetURL, withIntermediateDirectories: true)
+        try "stale".write(
+            to: targetURL.appendingPathComponent("stale.txt"),
+            atomically: true,
+            encoding: .utf8
+        )
+
+        do {
+            try await viewModel.createWorkspaceWorktree(
+                from: fixture.repositoryURL.path,
+                branch: branch,
+                createBranch: true,
+                baseBranch: "main",
+                autoOpen: false,
+                targetPath: targetPath
+            )
+            XCTFail("预期创建失败，但实际成功")
+        } catch {
+            // expected
+        }
+
+        let presentation = try XCTUnwrap(
+            viewModel.workspaceWorktreeDeletePresentation(for: targetPath, from: fixture.repositoryURL.path)
+        )
+        XCTAssertEqual(presentation.kind, .clearFailedCreation)
+        XCTAssertEqual(presentation.actionTitle, "清除记录")
+    }
+
+    func testWorkspaceWorktreeDeletePresentationUsesDeleteForPersistedWorktree() async throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.initializeRepository(defaultBranch: "main")
+        try fixture.commit(fileName: "README.md", content: "hello")
+
+        let viewModel = fixture.makeViewModel()
+        viewModel.snapshot = NativeAppSnapshot(
+            appState: AppStateFile(),
+            projects: [fixture.makeProject()]
+        )
+
+        try await viewModel.createWorkspaceWorktree(
+            from: fixture.repositoryURL.path,
+            branch: "feature/delete-real",
+            createBranch: true,
+            baseBranch: "main",
+            autoOpen: false
+        )
+
+        let worktreePath = try XCTUnwrap(viewModel.snapshot.projects.first?.worktrees.first?.path)
+        let presentation = try XCTUnwrap(
+            viewModel.workspaceWorktreeDeletePresentation(for: worktreePath, from: fixture.repositoryURL.path)
+        )
+        XCTAssertEqual(presentation.kind, .deletePersistedWorktree)
+        XCTAssertEqual(presentation.actionTitle, "删除")
+    }
+
+    func testDeleteWorkspaceWorktreeRemovesCreatedBranch() async throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.initializeRepository(defaultBranch: "main")
+        try fixture.commit(fileName: "README.md", content: "hello")
+
+        let viewModel = fixture.makeViewModel()
+        viewModel.snapshot = NativeAppSnapshot(
+            appState: AppStateFile(),
+            projects: [fixture.makeProject()]
+        )
+
+        try await viewModel.createWorkspaceWorktree(
+            from: fixture.repositoryURL.path,
+            branch: "feature/delete-branch-too",
+            createBranch: true,
+            baseBranch: "main",
+            autoOpen: false
+        )
+
+        let worktreePath = try XCTUnwrap(viewModel.snapshot.projects.first?.worktrees.first?.path)
+        try await viewModel.deleteWorkspaceWorktree(worktreePath, from: fixture.repositoryURL.path)
+
+        let remainingBranch = try fixture.git(in: fixture.repositoryURL, ["branch", "--list", "feature/delete-branch-too"])
+        XCTAssertTrue(remainingBranch.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+        XCTAssertEqual(viewModel.snapshot.projects.first?.worktrees.count, 0)
+    }
+
+    func testOpenWorkspaceWorktreeKeepsWorkspacePresentedWhenExistingSessionHasTrailingSlash() throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        let viewModel = fixture.makeViewModel()
+        let persistedWorktreePath = fixture.rootURL
+            .appendingPathComponent("managed/fix/worktree", isDirectory: true)
+            .path
+        let restoredWorktreePath = persistedWorktreePath + "/"
+        var rootProject = fixture.makeProject()
+        rootProject.worktrees = [
+            ProjectWorktree(
+                id: "worktree:\(restoredWorktreePath)",
+                name: "worktree",
+                path: persistedWorktreePath,
+                branch: "fix/worktree",
+                baseBranch: "main",
+                inheritConfig: true,
+                created: Date().timeIntervalSinceReferenceDate
+            )
+        ]
+        viewModel.snapshot = NativeAppSnapshot(
+            appState: AppStateFile(),
+            projects: [rootProject]
+        )
+        viewModel.openWorkspaceSessions = [
+            OpenWorkspaceSessionState(
+                projectPath: restoredWorktreePath,
+                rootProjectPath: fixture.repositoryURL.path,
+                controller: GhosttyWorkspaceController(projectPath: restoredWorktreePath)
+            )
+        ]
+
+        viewModel.openWorkspaceWorktree(persistedWorktreePath, from: fixture.repositoryURL.path)
+
+        XCTAssertEqual(viewModel.activeWorkspaceProjectPath, persistedWorktreePath)
+        XCTAssertEqual(viewModel.selectedProjectPath, persistedWorktreePath)
+        XCTAssertNotNil(viewModel.activeWorkspaceController)
+        XCTAssertEqual(viewModel.activeWorkspaceController?.projectPath, restoredWorktreePath)
+        XCTAssertTrue(viewModel.isWorkspacePresented)
+        XCTAssertEqual(viewModel.openWorkspaceSessions.count, 1)
+    }
+
+    func testCreateWorkspaceWorktreeRejectsUsingRepositoryRootAsTargetPath() async throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.initializeRepository(defaultBranch: "main")
+        try fixture.commit(fileName: "README.md", content: "hello")
+
+        let viewModel = fixture.makeViewModel()
+        viewModel.snapshot = NativeAppSnapshot(
+            appState: AppStateFile(),
+            projects: [fixture.makeProject()]
+        )
+
+        do {
+            try await viewModel.createWorkspaceWorktree(
+                from: fixture.repositoryURL.path,
+                branch: "feature/same-root",
+                createBranch: true,
+                baseBranch: "main",
+                autoOpen: false,
+                targetPath: fixture.repositoryURL.path
+            )
+            XCTFail("预期主仓库目录作为 targetPath 会被拒绝，但实际成功")
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            XCTAssertTrue(message.contains("主仓库目录相同"), "错误文案应提示 targetPath 非法，实际：\(message)")
+        }
+    }
+
+    func testCreateWorkspaceWorktreeRejectsRelativeExplicitTargetPath() async throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.initializeRepository(defaultBranch: "main")
+        try fixture.commit(fileName: "README.md", content: "hello")
+
+        let viewModel = fixture.makeViewModel()
+        viewModel.snapshot = NativeAppSnapshot(
+            appState: AppStateFile(),
+            projects: [fixture.makeProject()]
+        )
+
+        do {
+            try await viewModel.createWorkspaceWorktree(
+                from: fixture.repositoryURL.path,
+                branch: "feature/relative-path",
+                createBranch: true,
+                baseBranch: "main",
+                autoOpen: false,
+                targetPath: "relative/path"
+            )
+            XCTFail("预期相对路径 targetPath 会被拒绝，但实际成功")
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            XCTAssertTrue(message.contains("绝对路径"), "错误文案应提示 targetPath 必须是绝对路径，实际：\(message)")
+        }
+    }
+
+    func testCreateWorkspaceWorktreeRejectsAbsoluteTargetPathOutsideManagedRoot() async throws {
+        let fixture = try GitWorktreeCreationFixture.make()
+        defer { fixture.cleanup() }
+
+        try fixture.initializeRepository(defaultBranch: "main")
+        try fixture.commit(fileName: "README.md", content: "hello")
+
+        let viewModel = fixture.makeViewModel()
+        viewModel.snapshot = NativeAppSnapshot(
+            appState: AppStateFile(),
+            projects: [fixture.makeProject()]
+        )
+
+        let externalPath = fixture.rootURL.appendingPathComponent("external-worktree", isDirectory: true).path
+        do {
+            try await viewModel.createWorkspaceWorktree(
+                from: fixture.repositoryURL.path,
+                branch: "feature/outside-managed-root",
+                createBranch: true,
+                baseBranch: "main",
+                autoOpen: false,
+                targetPath: externalPath
+            )
+            XCTFail("预期 managed root 外的绝对路径会被拒绝，但实际成功")
+        } catch {
+            let message = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+            XCTAssertTrue(message.contains("管理的 worktree 目录"), "错误文案应提示 targetPath 必须位于 managed root，实际：\(message)")
+        }
+    }
+
+    func testWorkspaceSidebarWorktreeItemDoesNotFallbackToPersistedTransientStatus() {
+        let now = Date().timeIntervalSinceReferenceDate
+        let persistedWorktree = ProjectWorktree(
+            id: "worktree:/tmp/legacy",
+            name: "legacy",
+            path: "/tmp/legacy",
+            branch: "feature/legacy",
+            inheritConfig: true,
+            created: now,
+            status: "failed",
+            initStep: NativeWorktreeInitStep.failed.rawValue,
+            initMessage: "legacy message",
+            initError: "legacy error",
+            updatedAt: now
+        )
+
+        let item = WorkspaceSidebarWorktreeItem(
+            rootProjectPath: "/tmp/repo",
+            worktree: persistedWorktree,
+            isOpen: false,
+            isActive: false
+        )
+
+        XCTAssertNil(item.status)
+        XCTAssertNil(item.initStep)
+        XCTAssertNil(item.initMessage)
+        XCTAssertNil(item.initError)
+        XCTAssertEqual(item.displayState, .normal)
+    }
+}
+
+private enum GitWorktreeCreationFixtureError: LocalizedError {
+    case commandFailed(String)
+
+    var errorDescription: String? {
+        switch self {
+        case let .commandFailed(message):
+            message
+        }
+    }
+}
+
+private struct GitWorktreeCreationFixture {
+    let rootURL: URL
+    let homeURL: URL
+    let repositoryURL: URL
+
+    static func make() throws -> GitWorktreeCreationFixture {
+        let rootURL = FileManager.default.temporaryDirectory
+            .appendingPathComponent("devhaven-worktree-creation-\(UUID().uuidString)", isDirectory: true)
+        let homeURL = rootURL.appendingPathComponent("home", isDirectory: true)
+        let repositoryURL = rootURL.appendingPathComponent("repo", isDirectory: true)
+        try FileManager.default.createDirectory(at: homeURL, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(at: repositoryURL, withIntermediateDirectories: true)
+        return GitWorktreeCreationFixture(rootURL: rootURL, homeURL: homeURL, repositoryURL: repositoryURL)
+    }
+
+    func cleanup() {
+        try? FileManager.default.removeItem(at: rootURL)
+    }
+
+    func initializeRepository(defaultBranch: String) throws {
+        try git(in: repositoryURL, ["init", "-b", defaultBranch])
+        try git(in: repositoryURL, ["config", "user.name", "DevHaven Tests"])
+        try git(in: repositoryURL, ["config", "user.email", "devhaven-tests@example.com"])
+    }
+
+    func commit(fileName: String, content: String) throws {
+        let fileURL = repositoryURL.appendingPathComponent(fileName)
+        try content.write(to: fileURL, atomically: true, encoding: .utf8)
+        try git(in: repositoryURL, ["add", fileName])
+        try git(in: repositoryURL, ["commit", "-m", "init"])
+    }
+
+    @MainActor
+    func makeViewModel(
+        worktreeService: (any NativeWorktreeServicing)? = nil,
+        worktreeEnvironmentService: (any NativeWorktreeEnvironmentServicing)? = nil
+    ) -> NativeAppViewModel {
+        NativeAppViewModel(
+            store: LegacyCompatStore(homeDirectoryURL: homeURL),
+            worktreeService: worktreeService ?? NativeGitWorktreeService(homeDirectoryURL: homeURL),
+            worktreeEnvironmentService: worktreeEnvironmentService
+        )
+    }
+
+    func makeProject() -> Project {
+        let now = Date().timeIntervalSinceReferenceDate
+        return Project(
+            id: UUID().uuidString,
+            name: repositoryURL.lastPathComponent,
+            path: repositoryURL.path,
+            tags: [],
+            runConfigurations: [],
+            worktrees: [],
+            mtime: now,
+            size: 0,
+            checksum: UUID().uuidString,
+            isGitRepository: true,
+            gitCommits: 0,
+            gitLastCommit: now,
+            created: now,
+            checked: now
+        )
+    }
+
+    @discardableResult
+    func git(in directoryURL: URL, _ arguments: [String]) throws -> String {
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["git"] + arguments
+        process.currentDirectoryURL = directoryURL
+
+        let stdout = Pipe()
+        let stderr = Pipe()
+        process.standardOutput = stdout
+        process.standardError = stderr
+
+        try process.run()
+        process.waitUntilExit()
+
+        let stdoutText = String(data: stdout.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        let stderrText = String(data: stderr.fileHandleForReading.readDataToEndOfFile(), encoding: .utf8) ?? ""
+        guard process.terminationStatus == 0 else {
+            let message = [stdoutText, stderrText]
+                .map { $0.trimmingCharacters(in: .whitespacesAndNewlines) }
+                .first(where: { !$0.isEmpty }) ?? "未知错误"
+            throw GitWorktreeCreationFixtureError.commandFailed(
+                "git \(arguments.joined(separator: " ")) 失败：\(message)"
+            )
+        }
+        return stdoutText
+    }
+}
+
+private struct StubWorktreeEnvironmentService: NativeWorktreeEnvironmentServicing {
+    let result: NativeWorktreeEnvironmentResult
+
+    func prepareEnvironment(
+        mainRepositoryPath: String,
+        worktreePath: String,
+        workspaceName: String
+    ) -> NativeWorktreeEnvironmentResult {
+        result
+    }
+}
+
+private final class BlockingWorktreeService: NativeWorktreeServicing, @unchecked Sendable {
+    private let previewPath: String
+    private let defaultBranch: String
+    private let createStarted = DispatchSemaphore(value: 0)
+    private let allowFinish = DispatchSemaphore(value: 0)
+    private let lock = NSLock()
+    private var finishedBranches = [String: String]()
+
+    init(previewPath: String, defaultBranch: String) {
+        self.previewPath = previewPath
+        self.defaultBranch = defaultBranch
+    }
+
+    func managedWorktreePath(for sourceProjectPath: String, branch: String) throws -> String {
+        previewPath
+    }
+
+    func preflightCreateWorktree(_ request: NativeWorktreeCreateRequest) throws -> String {
+        previewPath
+    }
+
+    func currentBranch(at projectPath: String) throws -> String {
+        defaultBranch
+    }
+
+    func listBranches(at projectPath: String) throws -> [NativeGitBranch] {
+        lock.lock()
+        defer { lock.unlock() }
+        let createdBranches = finishedBranches.values.sorted()
+        let allBranches = [defaultBranch] + createdBranches
+        return Array(Set(allBranches)).sorted().map { NativeGitBranch(name: $0, isMain: $0 == defaultBranch) }
+    }
+
+    func listWorktrees(at projectPath: String) throws -> [NativeGitWorktree] {
+        lock.lock()
+        defer { lock.unlock() }
+        return finishedBranches.map { NativeGitWorktree(path: $0.key, branch: $0.value) }
+    }
+
+    func createWorktree(
+        _ request: NativeWorktreeCreateRequest,
+        progress: @escaping @Sendable (NativeWorktreeProgress) -> Void
+    ) throws -> NativeWorktreeCreateResult {
+        progress(
+            NativeWorktreeProgress(
+                worktreePath: previewPath,
+                branch: request.branch,
+                baseBranch: request.baseBranch,
+                step: .checkingBranch,
+                message: "执行中：校验分支与基线可用性..."
+            )
+        )
+        createStarted.signal()
+        allowFinish.wait()
+        lock.lock()
+        finishedBranches[previewPath] = request.branch
+        lock.unlock()
+        return NativeWorktreeCreateResult(
+            worktreePath: previewPath,
+            branch: request.branch,
+            baseBranch: request.baseBranch
+        )
+    }
+
+    func removeWorktree(_ request: NativeWorktreeRemoveRequest) throws -> NativeWorktreeRemoveResult {
+        lock.lock()
+        finishedBranches.removeValue(forKey: request.worktreePath)
+        lock.unlock()
+        return NativeWorktreeRemoveResult()
+    }
+
+    func cleanupFailedWorktreeCreate(_ request: NativeWorktreeCleanupRequest) throws -> NativeWorktreeCleanupResult {
+        lock.lock()
+        finishedBranches.removeValue(forKey: request.worktreePath)
+        lock.unlock()
+        return NativeWorktreeCleanupResult()
+    }
+
+    func waitUntilCreateStarts(timeout: TimeInterval = 1.0) -> Bool {
+        createStarted.wait(timeout: .now() + timeout) == .success
+    }
+
+    func finishCreate() {
+        allowFinish.signal()
+    }
+}


### PR DESCRIPTION
## 变更摘要

这次 PR 主要修复了 DevHaven 在 worktree 创建、删除、恢复和侧栏交互上的一组连锁问题：

- 修复 worktree 创建失败后残留 branch / 目录 / git metadata，导致后续误报“分支已存在”或“目录已存在”
- 将 pending create 状态从持久化 worktree 元数据中拆出，避免 transient 状态污染真实 worktree 列表
- 新增 `NativeWorktreeEnvironmentService`，把 worktree 创建成功后的环境准备独立出来；即使 bootstrap 有告警，也不再把真实 worktree 误标成失败
- 删除 worktree 时同步删除对应本地分支；若分支有未合并提交，则回退为强制删除
- 统一 `NativeAppViewModel` 中 workspace session / worktree path 的规范化比较，修复 trailing slash 不一致导致点击 worktree 后回到首页的问题
- 扩大侧栏项目行和 worktree 行主区域的点击热区，避免只能点到文字才能打开

## 解决的问题

### 1. worktree 创建/删除链路不稳
- 创建不存在的分支时，偶发误报“分支已存在”
- 使用已有分支创建时，偶发误报“目录已存在”
- 失败创建后会留下脏状态，影响后续重试
- 删除 worktree 后未同步删除对应分支
- bootstrap 命令失败时，真实创建成功的 worktree 可能被错误标记为失败

### 2. workspace 恢复后点击 worktree 会回主页
- restore snapshot 中 session path 可能带尾部 `/`
- persisted worktree path 可能不带尾部 `/`
- 之前部分 session/controller 查找仍使用精确字符串匹配
- 导致 `activeWorkspaceController` 取不到，`isWorkspacePresented` 变成 `false`
- 用户点击侧栏 worktree 行时，视觉上会直接回到首页

### 3. 侧栏点击热区太窄
- 项目行 / worktree 行虽然看起来是一整块，但实际经常只有文字区域可点
- 现在改成主内容区域都能稳定触发打开动作，右侧操作按钮仍然保持独立

## 实现说明

### worktree 生命周期加固
- 增强 create preflight 和 failed-create cleanup
- runtime-only 维护 pending worktree create 状态，不再把 creating / failed 这类瞬态状态写入持久化 `snapshot.projects[].worktrees`
- refresh 后把 pending 元数据按需提升为真实 persisted worktree 元数据

### 环境准备拆分
- 新增 `NativeWorktreeEnvironmentService`
- `git worktree add` 成功后，再执行环境准备
- 环境准备失败只产生 warning，不再回滚真实 worktree

### 删除分支逻辑补齐
- 保留 baseBranch / created-branch 元数据，供后续删除使用
- 删除 worktree 时同步删除关联本地分支
- 对未合并提交的分支回退为强制删除

### path normalize 收口
- 统一 `NativeAppViewModel` 中 workspace session/controller/path 的查找逻辑
- restore 进来的 session path 会先做 canonicalize
- active/selected workspace 也会优先回到 canonical session path
- 修复已存在 session 路径带尾斜杠时，点击 worktree 仍能稳定进入 workspace

### 侧栏热区修复
- 项目行与 worktree 行的主按钮区域都显式扩展到最大宽度
- 对按钮和 label 根视图都补齐 `contentShape(...)`
- 保留右侧删除/重试等操作区的独立点击行为

## 验证

已执行：

```bash
swift test --package-path macos
git diff --check
```

结果：

- 45 个测试全部通过
- 0 failures
- `git diff --check` 通过

## 回归覆盖

新增/覆盖了以下关键场景：

- 创建失败后清理残留 branch 和目录
- unborn HEAD 下 current branch fallback
- refresh worktrees 对 unborn HEAD 容错
- bootstrap warning 不再把真实 worktree 标记为失败
- 删除 worktree 时删除已创建分支，包括未合并提交时的 force delete fallback
- 已存在 restored session path 带 trailing slash 时，点击 worktree 仍保持 `isWorkspacePresented == true`
- start-create 流程继续保证 overlay 在 sheet dismiss 后再显示
