### PR TITLE
feat(macos): add workspace GitHub tool window

### DIFF
--- a/macos/Sources/DevHavenApp/WorkspaceChromeContainerView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceChromeContainerView.swift
@@ -42,7 +42,10 @@ struct WorkspaceChromeContainerView<Content: View>: View {
 
             Spacer(minLength: 0)
 
-            toolWindowStripeButton(kind: .git)
+            VStack(spacing: 8) {
+                toolWindowStripeButton(kind: .git)
+                toolWindowStripeButton(kind: .github)
+            }
         }
         .padding(.vertical, 8)
         .frame(width: 44)

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubDetailSidebarView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubDetailSidebarView.swift
@@ -1,0 +1,131 @@
+import SwiftUI
+import DevHavenCore
+
+struct WorkspaceGitHubDetailSidebarView<Content: View>: View {
+    private let content: () -> Content
+
+    init(@ViewBuilder content: @escaping () -> Content) {
+        self.content = content
+    }
+
+    var body: some View {
+        ScrollView {
+            VStack(alignment: .leading, spacing: 16) {
+                content()
+            }
+            .padding(16)
+        }
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        .background(NativeTheme.surface)
+    }
+}
+
+struct WorkspaceGitHubDetailSidebarSection<Content: View>: View {
+    let title: String
+    private let content: () -> Content
+
+    init(title: String, @ViewBuilder content: @escaping () -> Content) {
+        self.title = title
+        self.content = content
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(NativeTheme.textSecondary)
+                .textCase(.uppercase)
+            content()
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(NativeTheme.elevated)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(NativeTheme.border, lineWidth: 1)
+        )
+        .clipShape(.rect(cornerRadius: 12))
+    }
+}
+
+struct WorkspaceGitHubMetadataRow: View {
+    let title: String
+    let value: String
+
+    var body: some View {
+        HStack(alignment: .top, spacing: 10) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(NativeTheme.textSecondary)
+            Spacer(minLength: 8)
+            Text(value)
+                .font(.caption)
+                .foregroundStyle(NativeTheme.textPrimary)
+                .multilineTextAlignment(.trailing)
+                .textSelection(.enabled)
+        }
+    }
+}
+
+struct WorkspaceGitHubActorListView: View {
+    let actors: [WorkspaceGitHubActor]
+
+    var body: some View {
+        if actors.isEmpty {
+            Text("暂无")
+                .font(.caption)
+                .foregroundStyle(NativeTheme.textSecondary)
+        } else {
+            VStack(alignment: .leading, spacing: 8) {
+                ForEach(actorEntries, id: \.id) { entry in
+                    Text(entry.title)
+                        .font(.callout)
+                        .foregroundStyle(NativeTheme.textPrimary)
+                }
+            }
+        }
+    }
+
+    private var actorEntries: [(id: String, title: String)] {
+        actors.enumerated().map { index, actor in
+            let baseID = actor.nodeID ?? actor.login ?? actor.name ?? "actor"
+            let title: String
+            if let login = actor.login,
+               let name = actor.name,
+               !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty,
+               name != login {
+                title = "\(name) (@\(login))"
+            } else if let login = actor.login,
+                      !login.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                title = "@\(login)"
+            } else {
+                title = actor.displayName
+            }
+            return ("\(baseID)-\(index)", title)
+        }
+    }
+}
+
+struct WorkspaceGitHubLabelListView: View {
+    let labels: [WorkspaceGitHubLabel]
+
+    var body: some View {
+        if labels.isEmpty {
+            Text("暂无")
+                .font(.caption)
+                .foregroundStyle(NativeTheme.textSecondary)
+        } else {
+            VStack(alignment: .leading, spacing: 6) {
+                ForEach(labels) { label in
+                    Text(label.name)
+                        .font(.caption.weight(.semibold))
+                        .padding(.horizontal, 8)
+                        .padding(.vertical, 4)
+                        .background(gitHubLabelColor(label.color ?? "").opacity(0.18))
+                        .foregroundStyle(NativeTheme.textPrimary)
+                        .clipShape(.capsule)
+                }
+            }
+        }
+    }
+}

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubIssueDetailView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubIssueDetailView.swift
@@ -3,7 +3,9 @@ import SwiftUI
 import DevHavenCore
 
 struct WorkspaceGitHubIssueDetailView: View {
+    @Bindable var viewModel: WorkspaceGitHubViewModel
     let detail: WorkspaceGitHubIssueDetail
+    let onCreateIssueWorktree: ((WorkspaceGitHubIssueDetail) throws -> Void)?
     @State private var splitRatio = 0.68
 
     var body: some View {
@@ -17,6 +19,13 @@ struct WorkspaceGitHubIssueDetailView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 16) {
                         header
+                        if let actionBanner {
+                            feedbackBanner(
+                                message: actionBanner.message,
+                                tint: actionBanner.tint
+                            )
+                        }
+                        actionsSection
                         bodySection
                         commentsSection
                     }
@@ -101,11 +110,88 @@ struct WorkspaceGitHubIssueDetailView: View {
         .clipShape(.rect(cornerRadius: 14))
     }
 
+    private var actionsSection: some View {
+        sectionCard(title: "Actions") {
+            VStack(alignment: .leading, spacing: 14) {
+                VStack(alignment: .leading, spacing: 6) {
+                    Text("建议分支")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(NativeTheme.textSecondary)
+                    Text(detail.suggestedBranchName)
+                        .font(.callout.monospaced())
+                        .foregroundStyle(NativeTheme.textPrimary)
+                        .textSelection(.enabled)
+                }
+
+                HStack(spacing: 8) {
+                    Button("创建并切换分支") {
+                        viewModel.createAndCheckoutBranchForSelectedIssue()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(viewModel.isMutating)
+
+                    Button("创建 worktree 并打开") {
+                        do {
+                            try onCreateIssueWorktree?(detail)
+                            viewModel.reportExternalMutationSuccess(.createIssueWorktree)
+                        } catch {
+                            viewModel.reportMutationFailure(error)
+                        }
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(viewModel.isMutating || onCreateIssueWorktree == nil)
+                }
+
+                HStack(spacing: 8) {
+                    switch detail.state {
+                    case .open:
+                        Button("关闭 Issue", role: .destructive) {
+                            viewModel.closeSelectedIssue()
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(viewModel.isMutating)
+                    case .closed:
+                        Button("重新打开 Issue") {
+                            viewModel.reopenSelectedIssue()
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(viewModel.isMutating)
+                    case .unknown:
+                        EmptyView()
+                    }
+                    Spacer(minLength: 0)
+                }
+
+                VStack(alignment: .leading, spacing: 8) {
+                    Text("新增评论")
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(NativeTheme.textSecondary)
+                    TextEditor(text: $viewModel.issueCommentDraft)
+                        .font(.callout)
+                        .frame(minHeight: 108)
+                        .padding(8)
+                        .background(NativeTheme.elevated)
+                        .clipShape(.rect(cornerRadius: 10))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(NativeTheme.border, lineWidth: 1)
+                        )
+
+                    HStack(spacing: 8) {
+                        Spacer(minLength: 0)
+                        Button("提交评论") {
+                            viewModel.addCommentToSelectedIssue()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(viewModel.isMutating || viewModel.issueCommentDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                    }
+                }
+            }
+        }
+    }
+
     private var bodySection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Description")
-                .font(.headline)
-                .foregroundStyle(NativeTheme.textPrimary)
+        sectionCard(title: "Description") {
             if (detail.body ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 Text("暂无描述")
                     .font(.callout)
@@ -118,50 +204,87 @@ struct WorkspaceGitHubIssueDetailView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .padding(14)
-        .background(NativeTheme.surface)
-        .overlay(
-            RoundedRectangle(cornerRadius: 14)
-                .stroke(NativeTheme.border, lineWidth: 1)
-        )
-        .clipShape(.rect(cornerRadius: 14))
     }
 
     private var commentsSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Comments")
-                .font(.headline)
-                .foregroundStyle(NativeTheme.textPrimary)
+        sectionCard(title: "Comments") {
             if detail.comments.isEmpty {
                 Text("暂无评论")
                     .font(.callout)
                     .foregroundStyle(NativeTheme.textSecondary)
             } else {
-                ForEach(detail.comments) { comment in
-                    VStack(alignment: .leading, spacing: 6) {
-                        HStack(spacing: 8) {
-                            Text(comment.author?.displayName ?? "Unknown")
-                                .font(.caption.weight(.semibold))
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(detail.comments) { comment in
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack(spacing: 8) {
+                                Text(comment.author?.displayName ?? "Unknown")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(NativeTheme.textPrimary)
+                                Text(gitHubRelativeDateText(comment.createdAt))
+                                    .font(.caption)
+                                    .foregroundStyle(NativeTheme.textSecondary)
+                            }
+                            Text(comment.body)
+                                .font(.callout)
                                 .foregroundStyle(NativeTheme.textPrimary)
-                            Text(gitHubRelativeDateText(comment.createdAt))
-                                .font(.caption)
-                                .foregroundStyle(NativeTheme.textSecondary)
+                                .textSelection(.enabled)
                         }
-                        Text(comment.body)
-                            .font(.callout)
-                            .foregroundStyle(NativeTheme.textPrimary)
-                            .textSelection(.enabled)
+                        .padding(12)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(NativeTheme.elevated)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(NativeTheme.border, lineWidth: 1)
+                        )
+                        .clipShape(.rect(cornerRadius: 12))
                     }
-                    .padding(12)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(NativeTheme.elevated)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(NativeTheme.border, lineWidth: 1)
-                    )
-                    .clipShape(.rect(cornerRadius: 12))
                 }
             }
+        }
+    }
+
+    private var actionBanner: (message: String, tint: Color)? {
+        if let mutationErrorMessage = viewModel.mutationErrorMessage,
+           !mutationErrorMessage.isEmpty {
+            return (mutationErrorMessage, NativeTheme.warning)
+        }
+        if let activeMutation = viewModel.activeMutation,
+           viewModel.isMutating,
+           isIssueMutation(activeMutation) {
+            return (gitHubMutationStatusText(activeMutation), NativeTheme.accent)
+        }
+        if let lastSuccessfulMutation = viewModel.lastSuccessfulMutation,
+           isIssueMutation(lastSuccessfulMutation) {
+            return (gitHubMutationSuccessText(lastSuccessfulMutation), .green)
+        }
+        return nil
+    }
+
+    private func isIssueMutation(_ kind: WorkspaceGitHubMutationKind) -> Bool {
+        switch kind {
+        case .addIssueComment, .closeIssue, .reopenIssue, .createIssueBranch, .createIssueWorktree:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func feedbackBanner(message: String, tint: Color) -> some View {
+        Text(message)
+            .font(.callout)
+            .foregroundStyle(tint)
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(tint.opacity(0.12))
+            .clipShape(.rect(cornerRadius: 12))
+    }
+
+    private func sectionCard<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(NativeTheme.textPrimary)
+            content()
         }
         .padding(14)
         .background(NativeTheme.surface)

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubIssueDetailView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubIssueDetailView.swift
@@ -1,0 +1,181 @@
+import AppKit
+import SwiftUI
+import DevHavenCore
+
+struct WorkspaceGitHubIssueDetailView: View {
+    let detail: WorkspaceGitHubIssueDetail
+    @State private var splitRatio = 0.68
+
+    var body: some View {
+        WorkspaceSplitView(
+            direction: .horizontal,
+            ratio: splitRatio,
+            onRatioChange: { splitRatio = $0 },
+            minLeadingSize: 360,
+            minTrailingSize: 220,
+            leading: {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        header
+                        bodySection
+                        commentsSection
+                    }
+                    .padding(16)
+                }
+                .background(NativeTheme.window)
+            },
+            trailing: {
+                WorkspaceGitHubDetailSidebarView {
+                    WorkspaceGitHubDetailSidebarSection(title: "Assignees") {
+                        WorkspaceGitHubActorListView(actors: detail.assignees)
+                    }
+
+                    WorkspaceGitHubDetailSidebarSection(title: "Labels") {
+                        WorkspaceGitHubLabelListView(labels: detail.labels)
+                    }
+
+                    if let milestone = detail.milestone {
+                        WorkspaceGitHubDetailSidebarSection(title: "Milestone") {
+                            Text(milestone.title)
+                                .font(.callout)
+                                .foregroundStyle(NativeTheme.textPrimary)
+                        }
+                    }
+
+                    WorkspaceGitHubDetailSidebarSection(title: "Details") {
+                        VStack(alignment: .leading, spacing: 8) {
+                            WorkspaceGitHubMetadataRow(title: "Created", value: gitHubAbsoluteDateText(detail.createdAt))
+                            WorkspaceGitHubMetadataRow(title: "Updated", value: gitHubAbsoluteDateText(detail.updatedAt))
+                            if let closedAt = detail.closedAt {
+                                WorkspaceGitHubMetadataRow(title: "Closed", value: gitHubAbsoluteDateText(closedAt))
+                            }
+                            if detail.stateReason != .none {
+                                WorkspaceGitHubMetadataRow(title: "Reason", value: gitHubIssueStateReasonTitle(detail.stateReason))
+                            }
+                            WorkspaceGitHubMetadataRow(title: "State", value: gitHubIssueStateTitle(detail.state, reason: detail.stateReason))
+                            WorkspaceGitHubMetadataRow(title: "Comments", value: "\(detail.commentsCount)")
+                        }
+                    }
+                }
+            }
+        )
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 12) {
+                Circle()
+                    .fill(gitHubIssueStateColor(detail.state))
+                    .frame(width: 12, height: 12)
+                    .padding(.top, 6)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(detail.title)
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(NativeTheme.textPrimary)
+                    Text("#\(detail.number)")
+                        .font(.callout)
+                        .foregroundStyle(NativeTheme.textSecondary)
+                    if let author = detail.author {
+                        Text("作者：\(author.login ?? author.displayName)")
+                            .font(.caption)
+                            .foregroundStyle(NativeTheme.textSecondary)
+                    }
+                }
+
+                Spacer(minLength: 0)
+
+                Button("Open in GitHub") {
+                    openURL(detail.url)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(NativeTheme.accent)
+            }
+        }
+        .padding(14)
+        .background(NativeTheme.surface)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(NativeTheme.border, lineWidth: 1)
+        )
+        .clipShape(.rect(cornerRadius: 14))
+    }
+
+    private var bodySection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Description")
+                .font(.headline)
+                .foregroundStyle(NativeTheme.textPrimary)
+            if (detail.body ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Text("暂无描述")
+                    .font(.callout)
+                    .foregroundStyle(NativeTheme.textSecondary)
+            } else {
+                Text(detail.body ?? "")
+                    .font(.callout)
+                    .foregroundStyle(NativeTheme.textPrimary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(14)
+        .background(NativeTheme.surface)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(NativeTheme.border, lineWidth: 1)
+        )
+        .clipShape(.rect(cornerRadius: 14))
+    }
+
+    private var commentsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Comments")
+                .font(.headline)
+                .foregroundStyle(NativeTheme.textPrimary)
+            if detail.comments.isEmpty {
+                Text("暂无评论")
+                    .font(.callout)
+                    .foregroundStyle(NativeTheme.textSecondary)
+            } else {
+                ForEach(detail.comments) { comment in
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack(spacing: 8) {
+                            Text(comment.author?.displayName ?? "Unknown")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(NativeTheme.textPrimary)
+                            Text(gitHubRelativeDateText(comment.createdAt))
+                                .font(.caption)
+                                .foregroundStyle(NativeTheme.textSecondary)
+                        }
+                        Text(comment.body)
+                            .font(.callout)
+                            .foregroundStyle(NativeTheme.textPrimary)
+                            .textSelection(.enabled)
+                    }
+                    .padding(12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(NativeTheme.elevated)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(NativeTheme.border, lineWidth: 1)
+                    )
+                    .clipShape(.rect(cornerRadius: 12))
+                }
+            }
+        }
+        .padding(14)
+        .background(NativeTheme.surface)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(NativeTheme.border, lineWidth: 1)
+        )
+        .clipShape(.rect(cornerRadius: 14))
+    }
+
+    private func openURL(_ string: String) {
+        guard let url = URL(string: string) else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubIssueDetailView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubIssueDetailView.swift
@@ -6,35 +6,39 @@ struct WorkspaceGitHubIssueDetailView: View {
     @Bindable var viewModel: WorkspaceGitHubViewModel
     let detail: WorkspaceGitHubIssueDetail
     let onCreateIssueWorktree: ((WorkspaceGitHubIssueDetail) throws -> Void)?
-    @State private var splitRatio = 0.68
+    @State private var splitRatio = 0.72
 
     var body: some View {
         WorkspaceSplitView(
             direction: .horizontal,
             ratio: splitRatio,
             onRatioChange: { splitRatio = $0 },
-            minLeadingSize: 360,
-            minTrailingSize: 220,
+            minLeadingSize: 420,
+            minTrailingSize: 260,
             leading: {
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 16) {
+                    VStack(alignment: .leading, spacing: 18) {
                         header
+
                         if let actionBanner {
                             feedbackBanner(
                                 message: actionBanner.message,
                                 tint: actionBanner.tint
                             )
                         }
-                        actionsSection
-                        bodySection
-                        commentsSection
+
+                        conversationSection
+                        commentComposerSection
                     }
-                    .padding(16)
+                    .padding(18)
                 }
                 .background(NativeTheme.window)
             },
             trailing: {
                 WorkspaceGitHubDetailSidebarView {
+                    statusSection
+                    developmentSection
+
                     WorkspaceGitHubDetailSidebarSection(title: "Assignees") {
                         WorkspaceGitHubActorListView(actors: detail.assignees)
                     }
@@ -61,7 +65,6 @@ struct WorkspaceGitHubIssueDetailView: View {
                             if detail.stateReason != .none {
                                 WorkspaceGitHubMetadataRow(title: "Reason", value: gitHubIssueStateReasonTitle(detail.stateReason))
                             }
-                            WorkspaceGitHubMetadataRow(title: "State", value: gitHubIssueStateTitle(detail.state, reason: detail.stateReason))
                             WorkspaceGitHubMetadataRow(title: "Comments", value: "\(detail.commentsCount)")
                         }
                     }
@@ -71,24 +74,26 @@ struct WorkspaceGitHubIssueDetailView: View {
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .top, spacing: 12) {
-                Circle()
-                    .fill(gitHubIssueStateColor(detail.state))
-                    .frame(width: 12, height: 12)
-                    .padding(.top, 6)
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 16) {
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(alignment: .firstTextBaseline, spacing: 10) {
+                        Text(detail.title)
+                            .font(.title2.weight(.semibold))
+                            .foregroundStyle(NativeTheme.textPrimary)
 
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(detail.title)
-                        .font(.title3.weight(.semibold))
-                        .foregroundStyle(NativeTheme.textPrimary)
-                    Text("#\(detail.number)")
-                        .font(.callout)
-                        .foregroundStyle(NativeTheme.textSecondary)
-                    if let author = detail.author {
-                        Text("作者：\(author.login ?? author.displayName)")
-                            .font(.caption)
+                        Text("#\(detail.number)")
+                            .font(.title3)
                             .foregroundStyle(NativeTheme.textSecondary)
+                    }
+
+                    HStack(alignment: .center, spacing: 10) {
+                        issueStateBadge
+
+                        Text(issueActivitySummary)
+                            .font(.callout)
+                            .foregroundStyle(NativeTheme.textSecondary)
+                            .lineLimit(2)
                     }
                 }
 
@@ -101,7 +106,7 @@ struct WorkspaceGitHubIssueDetailView: View {
                 .tint(NativeTheme.accent)
             }
         }
-        .padding(14)
+        .padding(16)
         .background(NativeTheme.surface)
         .overlay(
             RoundedRectangle(cornerRadius: 14)
@@ -110,20 +115,103 @@ struct WorkspaceGitHubIssueDetailView: View {
         .clipShape(.rect(cornerRadius: 14))
     }
 
-    private var actionsSection: some View {
-        sectionCard(title: "Actions") {
-            VStack(alignment: .leading, spacing: 14) {
-                VStack(alignment: .leading, spacing: 6) {
-                    Text("建议分支")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(NativeTheme.textSecondary)
-                    Text(detail.suggestedBranchName)
-                        .font(.callout.monospaced())
-                        .foregroundStyle(NativeTheme.textPrimary)
-                        .textSelection(.enabled)
+    private var conversationSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Conversation")
+                .font(.headline)
+                .foregroundStyle(NativeTheme.textPrimary)
+
+            timelineEntry(
+                iconSystemName: gitHubIssueStateSymbolName(detail.state),
+                iconTint: gitHubIssueStateColor(detail.state),
+                authorText: gitHubActorSummaryText(detail.author) ?? "未知用户",
+                headline: "opened this issue \(gitHubRelativeDateText(detail.createdAt))",
+                bodyText: trimmedBodyText ?? "暂无描述"
+            )
+
+            if detail.comments.isEmpty {
+                Text("暂无后续评论")
+                    .font(.callout)
+                    .foregroundStyle(NativeTheme.textSecondary)
+                    .padding(.leading, 40)
+            } else {
+                ForEach(detail.comments) { comment in
+                    timelineEntry(
+                        iconSystemName: "text.bubble.fill",
+                        iconTint: NativeTheme.accent,
+                        authorText: gitHubActorSummaryText(comment.author) ?? "未知用户",
+                        headline: "commented \(gitHubRelativeDateText(comment.createdAt))",
+                        bodyText: comment.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "空评论" : comment.body
+                    )
                 }
+            }
+        }
+    }
+
+    private var commentComposerSection: some View {
+        sectionCard(title: "Add a comment") {
+            VStack(alignment: .leading, spacing: 10) {
+                TextEditor(text: $viewModel.issueCommentDraft)
+                    .font(.callout)
+                    .frame(minHeight: 120)
+                    .padding(8)
+                    .background(NativeTheme.elevated)
+                    .clipShape(.rect(cornerRadius: 10))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(NativeTheme.border, lineWidth: 1)
+                    )
 
                 HStack(spacing: 8) {
+                    Spacer(minLength: 0)
+                    Button("提交评论") {
+                        viewModel.addCommentToSelectedIssue()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(viewModel.isMutating || trimmedCommentDraft == nil)
+                }
+            }
+        }
+    }
+
+    private var statusSection: some View {
+        WorkspaceGitHubDetailSidebarSection(title: "Status") {
+            VStack(alignment: .leading, spacing: 12) {
+                issueStateBadge
+
+                switch detail.state {
+                case .open:
+                    Button("关闭 Issue", role: .destructive) {
+                        viewModel.closeSelectedIssue()
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(viewModel.isMutating)
+                case .closed:
+                    Button("重新打开 Issue") {
+                        viewModel.reopenSelectedIssue()
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(viewModel.isMutating)
+                case .unknown:
+                    EmptyView()
+                }
+            }
+        }
+    }
+
+    private var developmentSection: some View {
+        WorkspaceGitHubDetailSidebarSection(title: "Development") {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("建议分支")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(NativeTheme.textSecondary)
+
+                Text(detail.suggestedBranchName)
+                    .font(.callout.monospaced())
+                    .foregroundStyle(NativeTheme.textPrimary)
+                    .textSelection(.enabled)
+
+                VStack(alignment: .leading, spacing: 8) {
                     Button("创建并切换分支") {
                         viewModel.createAndCheckoutBranchForSelectedIssue()
                     }
@@ -141,106 +229,53 @@ struct WorkspaceGitHubIssueDetailView: View {
                     .buttonStyle(.bordered)
                     .disabled(viewModel.isMutating || onCreateIssueWorktree == nil)
                 }
-
-                HStack(spacing: 8) {
-                    switch detail.state {
-                    case .open:
-                        Button("关闭 Issue", role: .destructive) {
-                            viewModel.closeSelectedIssue()
-                        }
-                        .buttonStyle(.bordered)
-                        .disabled(viewModel.isMutating)
-                    case .closed:
-                        Button("重新打开 Issue") {
-                            viewModel.reopenSelectedIssue()
-                        }
-                        .buttonStyle(.bordered)
-                        .disabled(viewModel.isMutating)
-                    case .unknown:
-                        EmptyView()
-                    }
-                    Spacer(minLength: 0)
-                }
-
-                VStack(alignment: .leading, spacing: 8) {
-                    Text("新增评论")
-                        .font(.caption.weight(.semibold))
-                        .foregroundStyle(NativeTheme.textSecondary)
-                    TextEditor(text: $viewModel.issueCommentDraft)
-                        .font(.callout)
-                        .frame(minHeight: 108)
-                        .padding(8)
-                        .background(NativeTheme.elevated)
-                        .clipShape(.rect(cornerRadius: 10))
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 10)
-                                .stroke(NativeTheme.border, lineWidth: 1)
-                        )
-
-                    HStack(spacing: 8) {
-                        Spacer(minLength: 0)
-                        Button("提交评论") {
-                            viewModel.addCommentToSelectedIssue()
-                        }
-                        .buttonStyle(.borderedProminent)
-                        .disabled(viewModel.isMutating || viewModel.issueCommentDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                    }
-                }
             }
         }
     }
 
-    private var bodySection: some View {
-        sectionCard(title: "Description") {
-            if (detail.body ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                Text("暂无描述")
-                    .font(.callout)
-                    .foregroundStyle(NativeTheme.textSecondary)
-            } else {
-                Text(detail.body ?? "")
-                    .font(.callout)
-                    .foregroundStyle(NativeTheme.textPrimary)
-                    .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+    private var issueStateBadge: some View {
+        let tint = gitHubIssueStateColor(detail.state)
+        return HStack(spacing: 6) {
+            Image(systemName: gitHubIssueStateSymbolName(detail.state))
+                .font(.system(size: 12, weight: .semibold))
+            Text(gitHubIssueStateTitle(detail.state, reason: detail.stateReason))
+                .font(.caption.weight(.semibold))
+        }
+        .foregroundStyle(tint)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(tint.opacity(0.12))
+        .overlay(
+            Capsule()
+                .stroke(tint.opacity(0.32), lineWidth: 1)
+        )
+        .clipShape(.capsule)
+    }
+
+    private var issueActivitySummary: String {
+        let authorText = gitHubActorSummaryText(detail.author) ?? "未知用户"
+        let openedText = "opened \(gitHubRelativeDateText(detail.createdAt))"
+        switch detail.state {
+        case .open:
+            return "\(authorText) \(openedText) · \(detail.commentsCount) comments"
+        case .closed:
+            if let closedAt = detail.closedAt {
+                return "\(authorText) \(openedText) · closed \(gitHubRelativeDateText(closedAt)) · \(detail.commentsCount) comments"
             }
+            return "\(authorText) \(openedText) · updated \(gitHubRelativeDateText(detail.updatedAt)) · \(detail.commentsCount) comments"
+        case .unknown:
+            return "\(authorText) updated \(gitHubRelativeDateText(detail.updatedAt)) · \(detail.commentsCount) comments"
         }
     }
 
-    private var commentsSection: some View {
-        sectionCard(title: "Comments") {
-            if detail.comments.isEmpty {
-                Text("暂无评论")
-                    .font(.callout)
-                    .foregroundStyle(NativeTheme.textSecondary)
-            } else {
-                VStack(alignment: .leading, spacing: 12) {
-                    ForEach(detail.comments) { comment in
-                        VStack(alignment: .leading, spacing: 6) {
-                            HStack(spacing: 8) {
-                                Text(comment.author?.displayName ?? "Unknown")
-                                    .font(.caption.weight(.semibold))
-                                    .foregroundStyle(NativeTheme.textPrimary)
-                                Text(gitHubRelativeDateText(comment.createdAt))
-                                    .font(.caption)
-                                    .foregroundStyle(NativeTheme.textSecondary)
-                            }
-                            Text(comment.body)
-                                .font(.callout)
-                                .foregroundStyle(NativeTheme.textPrimary)
-                                .textSelection(.enabled)
-                        }
-                        .padding(12)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(NativeTheme.elevated)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .stroke(NativeTheme.border, lineWidth: 1)
-                        )
-                        .clipShape(.rect(cornerRadius: 12))
-                    }
-                }
-            }
-        }
+    private var trimmedBodyText: String? {
+        let trimmed = detail.body?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
+
+    private var trimmedCommentDraft: String? {
+        let trimmed = viewModel.issueCommentDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private var actionBanner: (message: String, tint: Color)? {
@@ -266,6 +301,56 @@ struct WorkspaceGitHubIssueDetailView: View {
             return true
         default:
             return false
+        }
+    }
+
+    private func timelineEntry(
+        iconSystemName: String,
+        iconTint: Color,
+        authorText: String,
+        headline: String,
+        bodyText: String
+    ) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(iconTint.opacity(0.12))
+                    .frame(width: 28, height: 28)
+                Image(systemName: iconSystemName)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(iconTint)
+            }
+
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .center, spacing: 8) {
+                    Text(authorText)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(NativeTheme.textPrimary)
+
+                    Text(headline)
+                        .font(.caption)
+                        .foregroundStyle(NativeTheme.textSecondary)
+
+                    Spacer(minLength: 0)
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(NativeTheme.elevated)
+
+                Rectangle()
+                    .fill(NativeTheme.border)
+                    .frame(height: 1)
+
+                WorkspaceGitHubRenderedContentView(content: bodyText)
+                    .padding(14)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(NativeTheme.surface)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(NativeTheme.border, lineWidth: 1)
+            )
+            .clipShape(.rect(cornerRadius: 12))
         }
     }
 

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubIssuesView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubIssuesView.swift
@@ -24,39 +24,79 @@ struct WorkspaceGitHubIssuesView: View {
     }
 
     private var listPane: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 10) {
-                if viewModel.issues.isEmpty, !viewModel.isLoading {
-                    ContentUnavailableView(
-                        "暂无 Issues",
-                        systemImage: "circle.lefthalf.filled",
-                        description: Text("当前仓库没有符合条件的 Issue。")
-                    )
-                    .foregroundStyle(NativeTheme.textSecondary)
-                    .frame(maxWidth: .infinity, minHeight: 240)
-                } else {
-                    ForEach(viewModel.issues) { issue in
-                        WorkspaceGitHubIssueRowView(
-                            issue: issue,
-                            isSelected: viewModel.selectedIssueNumber == issue.number,
-                            onSelect: { viewModel.selectIssue(number: issue.number) }
+        VStack(spacing: 0) {
+            issueListHeader
+
+            Rectangle()
+                .fill(NativeTheme.border)
+                .frame(height: 1)
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    if viewModel.issues.isEmpty, !viewModel.isLoading {
+                        ContentUnavailableView(
+                            "暂无 Issues",
+                            systemImage: "exclamationmark.circle",
+                            description: Text("当前仓库没有符合条件的 Issue。")
                         )
-                        .contextMenu {
-                            Button("在 GitHub 中打开") {
-                                openURL(issue.url)
+                        .foregroundStyle(NativeTheme.textSecondary)
+                        .frame(maxWidth: .infinity, minHeight: 240)
+                    } else {
+                        ForEach(viewModel.issues) { issue in
+                            WorkspaceGitHubIssueRowView(
+                                issue: issue,
+                                isSelected: viewModel.selectedIssueNumber == issue.number,
+                                onSelect: { viewModel.selectIssue(number: issue.number) }
+                            )
+                            .contextMenu {
+                                Button("在 GitHub 中打开") {
+                                    openURL(issue.url)
+                                }
                             }
                         }
                     }
                 }
             }
-            .padding(12)
         }
-        .background(NativeTheme.sidebar)
+        .background(NativeTheme.surface)
         .overlay {
             if viewModel.isLoading {
                 WorkspaceGitHubListLoadingOverlay(title: "正在刷新 Issues…")
             }
         }
+    }
+
+    private var issueListHeader: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .center, spacing: 8) {
+                Text("Issues")
+                    .font(.headline)
+                    .foregroundStyle(NativeTheme.textPrimary)
+
+                Text("\(viewModel.issues.count)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(NativeTheme.textSecondary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(NativeTheme.elevated)
+                    .clipShape(.capsule)
+
+                Spacer(minLength: 0)
+            }
+
+            HStack(spacing: 8) {
+                filterBadge(title: viewModel.issueFilter.state.title, tint: issueFilterTint)
+
+                if let searchText = trimmedIssueSearchText {
+                    filterBadge(title: "搜索: \(searchText)", tint: NativeTheme.textSecondary)
+                }
+
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background(NativeTheme.sidebar)
     }
 
     @ViewBuilder
@@ -97,5 +137,35 @@ struct WorkspaceGitHubIssuesView: View {
             return
         }
         NSWorkspace.shared.open(url)
+    }
+
+    private var issueFilterTint: Color {
+        switch viewModel.issueFilter.state {
+        case .open:
+            return .green
+        case .closed:
+            return .purple
+        case .all:
+            return NativeTheme.textSecondary
+        }
+    }
+
+    private var trimmedIssueSearchText: String? {
+        let trimmed = viewModel.issueFilter.searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func filterBadge(title: String, tint: Color) -> some View {
+        Text(title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(tint)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(tint.opacity(0.12))
+            .overlay(
+                Capsule()
+                    .stroke(tint.opacity(0.28), lineWidth: 1)
+            )
+            .clipShape(.capsule)
     }
 }

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubIssuesView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubIssuesView.swift
@@ -1,0 +1,96 @@
+import AppKit
+import SwiftUI
+import DevHavenCore
+
+struct WorkspaceGitHubIssuesView: View {
+    @Bindable var viewModel: WorkspaceGitHubViewModel
+    @State private var splitRatio = 0.36
+
+    var body: some View {
+        WorkspaceSplitView(
+            direction: .horizontal,
+            ratio: splitRatio,
+            onRatioChange: { splitRatio = $0 },
+            minLeadingSize: 260,
+            minTrailingSize: 320,
+            leading: {
+                listPane
+            },
+            trailing: {
+                detailPane
+            }
+        )
+    }
+
+    private var listPane: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 10) {
+                if viewModel.issues.isEmpty, !viewModel.isLoading {
+                    ContentUnavailableView(
+                        "暂无 Issues",
+                        systemImage: "circle.lefthalf.filled",
+                        description: Text("当前仓库没有符合条件的 Issue。")
+                    )
+                    .foregroundStyle(NativeTheme.textSecondary)
+                    .frame(maxWidth: .infinity, minHeight: 240)
+                } else {
+                    ForEach(viewModel.issues) { issue in
+                        WorkspaceGitHubIssueRowView(
+                            issue: issue,
+                            isSelected: viewModel.selectedIssueNumber == issue.number,
+                            onSelect: { viewModel.selectIssue(number: issue.number) }
+                        )
+                        .contextMenu {
+                            Button("在 GitHub 中打开") {
+                                openURL(issue.url)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(12)
+        }
+        .background(NativeTheme.sidebar)
+        .overlay {
+            if viewModel.isLoading {
+                WorkspaceGitHubListLoadingOverlay(title: "正在刷新 Issues…")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var detailPane: some View {
+        if viewModel.isLoadingDetail {
+            ProgressView("正在加载 Issue 详情…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(NativeTheme.window)
+        } else if let detailErrorMessage = viewModel.detailErrorMessage {
+            ContentUnavailableView(
+                "Issue 详情加载失败",
+                systemImage: "exclamationmark.triangle",
+                description: Text(detailErrorMessage)
+            )
+            .foregroundStyle(NativeTheme.textSecondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(NativeTheme.window)
+        } else if let detail = viewModel.selectedIssueDetail {
+            WorkspaceGitHubIssueDetailView(detail: detail)
+        } else {
+            ContentUnavailableView(
+                "选择一个 Issue",
+                systemImage: "circle.lefthalf.filled",
+                description: Text("从左侧列表中选择一个 Issue 查看详情。")
+            )
+            .foregroundStyle(NativeTheme.textSecondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(NativeTheme.window)
+        }
+    }
+
+    private func openURL(_ string: String) {
+        guard let url = URL(string: string) else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubIssuesView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubIssuesView.swift
@@ -4,6 +4,7 @@ import DevHavenCore
 
 struct WorkspaceGitHubIssuesView: View {
     @Bindable var viewModel: WorkspaceGitHubViewModel
+    let onCreateIssueWorktree: ((WorkspaceGitHubIssueDetail) throws -> Void)?
     @State private var splitRatio = 0.36
 
     var body: some View {
@@ -74,7 +75,11 @@ struct WorkspaceGitHubIssuesView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(NativeTheme.window)
         } else if let detail = viewModel.selectedIssueDetail {
-            WorkspaceGitHubIssueDetailView(detail: detail)
+            WorkspaceGitHubIssueDetailView(
+                viewModel: viewModel,
+                detail: detail,
+                onCreateIssueWorktree: onCreateIssueWorktree
+            )
         } else {
             ContentUnavailableView(
                 "选择一个 Issue",

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubPullDetailView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubPullDetailView.swift
@@ -2,8 +2,15 @@ import AppKit
 import SwiftUI
 import DevHavenCore
 
+enum WorkspaceGitHubPullDetailActionMode: Equatable {
+    case pull
+    case review
+}
+
 struct WorkspaceGitHubPullDetailView: View {
+    @Bindable var viewModel: WorkspaceGitHubViewModel
     let detail: WorkspaceGitHubPullDetail
+    let actionMode: WorkspaceGitHubPullDetailActionMode
     @State private var splitRatio = 0.68
 
     var body: some View {
@@ -17,6 +24,18 @@ struct WorkspaceGitHubPullDetailView: View {
                 ScrollView {
                     VStack(alignment: .leading, spacing: 16) {
                         header
+                        if let actionBanner {
+                            feedbackBanner(
+                                message: actionBanner.message,
+                                tint: actionBanner.tint
+                            )
+                        }
+                        if actionMode == .review {
+                            reviewActionsSection
+                        } else {
+                            pullCommentSection
+                        }
+                        pullActionsSection
                         metrics
                         bodySection
                         commentsSection
@@ -96,6 +115,111 @@ struct WorkspaceGitHubPullDetailView: View {
         .clipShape(.rect(cornerRadius: 14))
     }
 
+    private var pullActionsSection: some View {
+        sectionCard(title: "Pull Request Actions") {
+            VStack(alignment: .leading, spacing: 14) {
+                HStack(spacing: 8) {
+                    Button("Checkout 分支") {
+                        viewModel.checkoutSelectedPullBranch()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(viewModel.isMutating)
+
+                    if canMergePull {
+                        Button("Merge") {
+                            viewModel.mergeSelectedPull()
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(viewModel.isMutating)
+                    }
+                }
+
+                HStack(spacing: 8) {
+                    switch detail.state {
+                    case .open:
+                        Button("关闭 PR", role: .destructive) {
+                            viewModel.closeSelectedPull()
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(viewModel.isMutating)
+                    case .closed:
+                        Button("重新打开 PR") {
+                            viewModel.reopenSelectedPull()
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(viewModel.isMutating)
+                    case .merged, .unknown:
+                        EmptyView()
+                    }
+                    Spacer(minLength: 0)
+                }
+            }
+        }
+    }
+
+    private var pullCommentSection: some View {
+        sectionCard(title: "新增评论") {
+            VStack(alignment: .leading, spacing: 8) {
+                TextEditor(text: $viewModel.pullCommentDraft)
+                    .font(.callout)
+                    .frame(minHeight: 108)
+                    .padding(8)
+                    .background(NativeTheme.elevated)
+                    .clipShape(.rect(cornerRadius: 10))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(NativeTheme.border, lineWidth: 1)
+                    )
+
+                HStack(spacing: 8) {
+                    Spacer(minLength: 0)
+                    Button("提交评论") {
+                        viewModel.addCommentToSelectedPull()
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(viewModel.isMutating || viewModel.pullCommentDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
+                }
+            }
+        }
+    }
+
+    private var reviewActionsSection: some View {
+        sectionCard(title: "Review Actions") {
+            VStack(alignment: .leading, spacing: 12) {
+                TextEditor(text: $viewModel.reviewCommentDraft)
+                    .font(.callout)
+                    .frame(minHeight: 108)
+                    .padding(8)
+                    .background(NativeTheme.elevated)
+                    .clipShape(.rect(cornerRadius: 10))
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 10)
+                            .stroke(NativeTheme.border, lineWidth: 1)
+                    )
+
+                HStack(spacing: 8) {
+                    Button("评论") {
+                        viewModel.submitReviewForSelectedPull(event: .comment)
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(viewModel.isMutating || !canSubmitReviewComment)
+
+                    Button("通过") {
+                        viewModel.submitReviewForSelectedPull(event: .approve)
+                    }
+                    .buttonStyle(.borderedProminent)
+                    .disabled(viewModel.isMutating || !canSubmitReview)
+
+                    Button("请求修改") {
+                        viewModel.submitReviewForSelectedPull(event: .requestChanges)
+                    }
+                    .buttonStyle(.bordered)
+                    .disabled(viewModel.isMutating || !canSubmitReviewComment)
+                }
+            }
+        }
+    }
+
     private var metrics: some View {
         HStack(spacing: 10) {
             metricCard("Files", value: "\(detail.changedFiles)")
@@ -125,10 +249,7 @@ struct WorkspaceGitHubPullDetailView: View {
     }
 
     private var bodySection: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            Text("Description")
-                .font(.headline)
-                .foregroundStyle(NativeTheme.textPrimary)
+        sectionCard(title: "Description") {
             if (detail.body ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                 Text("暂无描述")
                     .font(.callout)
@@ -141,50 +262,99 @@ struct WorkspaceGitHubPullDetailView: View {
                     .frame(maxWidth: .infinity, alignment: .leading)
             }
         }
-        .padding(14)
-        .background(NativeTheme.surface)
-        .overlay(
-            RoundedRectangle(cornerRadius: 14)
-                .stroke(NativeTheme.border, lineWidth: 1)
-        )
-        .clipShape(.rect(cornerRadius: 14))
     }
 
     private var commentsSection: some View {
-        VStack(alignment: .leading, spacing: 12) {
-            Text("Comments")
-                .font(.headline)
-                .foregroundStyle(NativeTheme.textPrimary)
+        sectionCard(title: "Comments") {
             if detail.comments.isEmpty {
                 Text("暂无评论")
                     .font(.callout)
                     .foregroundStyle(NativeTheme.textSecondary)
             } else {
-                ForEach(detail.comments) { comment in
-                    VStack(alignment: .leading, spacing: 6) {
-                        HStack(spacing: 8) {
-                            Text(comment.author?.displayName ?? "Unknown")
-                                .font(.caption.weight(.semibold))
+                VStack(alignment: .leading, spacing: 12) {
+                    ForEach(detail.comments) { comment in
+                        VStack(alignment: .leading, spacing: 6) {
+                            HStack(spacing: 8) {
+                                Text(comment.author?.displayName ?? "Unknown")
+                                    .font(.caption.weight(.semibold))
+                                    .foregroundStyle(NativeTheme.textPrimary)
+                                Text(gitHubRelativeDateText(comment.createdAt))
+                                    .font(.caption)
+                                    .foregroundStyle(NativeTheme.textSecondary)
+                            }
+                            Text(comment.body)
+                                .font(.callout)
                                 .foregroundStyle(NativeTheme.textPrimary)
-                            Text(gitHubRelativeDateText(comment.createdAt))
-                                .font(.caption)
-                                .foregroundStyle(NativeTheme.textSecondary)
+                                .textSelection(.enabled)
                         }
-                        Text(comment.body)
-                            .font(.callout)
-                            .foregroundStyle(NativeTheme.textPrimary)
-                            .textSelection(.enabled)
+                        .padding(12)
+                        .frame(maxWidth: .infinity, alignment: .leading)
+                        .background(NativeTheme.elevated)
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 12)
+                                .stroke(NativeTheme.border, lineWidth: 1)
+                        )
+                        .clipShape(.rect(cornerRadius: 12))
                     }
-                    .padding(12)
-                    .frame(maxWidth: .infinity, alignment: .leading)
-                    .background(NativeTheme.elevated)
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 12)
-                            .stroke(NativeTheme.border, lineWidth: 1)
-                    )
-                    .clipShape(.rect(cornerRadius: 12))
                 }
             }
+        }
+    }
+
+    private var canMergePull: Bool {
+        detail.state == .open && !detail.isDraft
+    }
+
+    private var canSubmitReview: Bool {
+        detail.state == .open && !detail.isDraft
+    }
+
+    private var canSubmitReviewComment: Bool {
+        canSubmitReview && !viewModel.reviewCommentDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+    }
+
+    private var actionBanner: (message: String, tint: Color)? {
+        if let mutationErrorMessage = viewModel.mutationErrorMessage,
+           !mutationErrorMessage.isEmpty {
+            return (mutationErrorMessage, NativeTheme.warning)
+        }
+        if let activeMutation = viewModel.activeMutation,
+           viewModel.isMutating,
+           isPullMutation(activeMutation) {
+            return (gitHubMutationStatusText(activeMutation), NativeTheme.accent)
+        }
+        if let lastSuccessfulMutation = viewModel.lastSuccessfulMutation,
+           isPullMutation(lastSuccessfulMutation) {
+            return (gitHubMutationSuccessText(lastSuccessfulMutation), .green)
+        }
+        return nil
+    }
+
+    private func isPullMutation(_ kind: WorkspaceGitHubMutationKind) -> Bool {
+        switch kind {
+        case .addPullComment, .closePull, .reopenPull, .mergePull, .checkoutPullBranch, .submitReview:
+            return true
+        default:
+            return false
+        }
+    }
+
+    private func feedbackBanner(message: String, tint: Color) -> some View {
+        Text(message)
+            .font(.callout)
+            .foregroundStyle(tint)
+            .padding(12)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(tint.opacity(0.12))
+            .clipShape(.rect(cornerRadius: 12))
+    }
+
+    private func sectionCard<Content: View>(title: String, @ViewBuilder content: () -> Content) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text(title)
+                .font(.headline)
+                .foregroundStyle(NativeTheme.textPrimary)
+            content()
         }
         .padding(14)
         .background(NativeTheme.surface)

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubPullDetailView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubPullDetailView.swift
@@ -11,47 +11,53 @@ struct WorkspaceGitHubPullDetailView: View {
     @Bindable var viewModel: WorkspaceGitHubViewModel
     let detail: WorkspaceGitHubPullDetail
     let actionMode: WorkspaceGitHubPullDetailActionMode
-    @State private var splitRatio = 0.68
+    @State private var splitRatio = 0.72
 
     var body: some View {
         WorkspaceSplitView(
             direction: .horizontal,
             ratio: splitRatio,
             onRatioChange: { splitRatio = $0 },
-            minLeadingSize: 360,
-            minTrailingSize: 220,
+            minLeadingSize: 420,
+            minTrailingSize: 260,
             leading: {
                 ScrollView {
-                    VStack(alignment: .leading, spacing: 16) {
+                    VStack(alignment: .leading, spacing: 18) {
                         header
+
                         if let actionBanner {
                             feedbackBanner(
                                 message: actionBanner.message,
                                 tint: actionBanner.tint
                             )
                         }
-                        if actionMode == .review {
-                            reviewActionsSection
-                        } else {
-                            pullCommentSection
-                        }
-                        pullActionsSection
-                        metrics
-                        bodySection
-                        commentsSection
+
+                        conversationSection
+                        composerSection
                     }
-                    .padding(16)
+                    .padding(18)
                 }
                 .background(NativeTheme.window)
             },
             trailing: {
                 WorkspaceGitHubDetailSidebarView {
+                    statusSection
+                    developmentSection
+
+                    WorkspaceGitHubDetailSidebarSection(title: "Assignees") {
+                        WorkspaceGitHubActorListView(actors: detail.assignees)
+                    }
+
                     WorkspaceGitHubDetailSidebarSection(title: "Labels") {
                         WorkspaceGitHubLabelListView(labels: detail.labels)
                     }
 
-                    WorkspaceGitHubDetailSidebarSection(title: "Assignees") {
-                        WorkspaceGitHubActorListView(actors: detail.assignees)
+                    if let milestone = detail.milestone {
+                        WorkspaceGitHubDetailSidebarSection(title: "Milestone") {
+                            Text(milestone.title)
+                                .font(.callout)
+                                .foregroundStyle(NativeTheme.textPrimary)
+                        }
                     }
 
                     WorkspaceGitHubDetailSidebarSection(title: "Details") {
@@ -62,11 +68,11 @@ struct WorkspaceGitHubPullDetailView: View {
                             WorkspaceGitHubMetadataRow(title: "Head", value: detail.headRefName)
                             WorkspaceGitHubMetadataRow(title: "Review", value: gitHubReviewDecisionTitle(detail.reviewDecision))
                             WorkspaceGitHubMetadataRow(title: "Merge", value: gitHubMergeStateTitle(detail.mergeStateStatus))
+                            WorkspaceGitHubMetadataRow(title: "Commits", value: "\(detail.commitCount)")
+                            WorkspaceGitHubMetadataRow(title: "Files", value: "\(detail.changedFiles)")
+                            WorkspaceGitHubMetadataRow(title: "Comments", value: "\(detail.commentsCount)")
                             if let mergedAt = detail.mergedAt {
                                 WorkspaceGitHubMetadataRow(title: "Merged", value: gitHubAbsoluteDateText(mergedAt))
-                            }
-                            if let milestone = detail.milestone {
-                                WorkspaceGitHubMetadataRow(title: "Milestone", value: milestone.title)
                             }
                         }
                     }
@@ -76,25 +82,31 @@ struct WorkspaceGitHubPullDetailView: View {
     }
 
     private var header: some View {
-        VStack(alignment: .leading, spacing: 10) {
-            HStack(alignment: .top, spacing: 12) {
-                Circle()
-                    .fill(gitHubPullStateColor(detail.state, isDraft: detail.isDraft))
-                    .frame(width: 12, height: 12)
-                    .padding(.top, 6)
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .top, spacing: 16) {
+                VStack(alignment: .leading, spacing: 10) {
+                    HStack(alignment: .firstTextBaseline, spacing: 10) {
+                        Text(detail.title)
+                            .font(.title2.weight(.semibold))
+                            .foregroundStyle(NativeTheme.textPrimary)
 
-                VStack(alignment: .leading, spacing: 6) {
-                    Text(detail.title)
-                        .font(.title3.weight(.semibold))
-                        .foregroundStyle(NativeTheme.textPrimary)
-                    Text("#\(detail.number) · \(detail.headRefName) -> \(detail.baseRefName)")
-                        .font(.callout)
-                        .foregroundStyle(NativeTheme.textSecondary)
-                    if let author = detail.author {
-                        Text("作者：\(author.login ?? author.displayName)")
-                            .font(.caption)
+                        Text("#\(detail.number)")
+                            .font(.title3)
                             .foregroundStyle(NativeTheme.textSecondary)
                     }
+
+                    HStack(alignment: .center, spacing: 10) {
+                        pullStateBadge
+
+                        Text(pullActivitySummary)
+                            .font(.callout)
+                            .foregroundStyle(NativeTheme.textSecondary)
+                            .lineLimit(2)
+                    }
+
+                    Text(branchSummary)
+                        .font(.caption)
+                        .foregroundStyle(NativeTheme.textSecondary)
                 }
 
                 Spacer(minLength: 0)
@@ -106,7 +118,7 @@ struct WorkspaceGitHubPullDetailView: View {
                 .tint(NativeTheme.accent)
             }
         }
-        .padding(14)
+        .padding(16)
         .background(NativeTheme.surface)
         .overlay(
             RoundedRectangle(cornerRadius: 14)
@@ -115,189 +127,215 @@ struct WorkspaceGitHubPullDetailView: View {
         .clipShape(.rect(cornerRadius: 14))
     }
 
-    private var pullActionsSection: some View {
-        sectionCard(title: "Pull Request Actions") {
-            VStack(alignment: .leading, spacing: 14) {
-                HStack(spacing: 8) {
-                    Button("Checkout 分支") {
-                        viewModel.checkoutSelectedPullBranch()
+    private var conversationSection: some View {
+        VStack(alignment: .leading, spacing: 14) {
+            Text("Conversation")
+                .font(.headline)
+                .foregroundStyle(NativeTheme.textPrimary)
+
+            timelineEntry(
+                iconSystemName: gitHubPullStateSymbolName(detail.state, isDraft: detail.isDraft),
+                iconTint: gitHubPullStateColor(detail.state, isDraft: detail.isDraft),
+                authorText: gitHubActorSummaryText(detail.author) ?? "未知用户",
+                headline: "opened this pull request \(gitHubRelativeDateText(detail.createdAt))",
+                bodyText: trimmedBodyText ?? "暂无描述"
+            )
+
+            if detail.comments.isEmpty {
+                Text("暂无后续评论")
+                    .font(.callout)
+                    .foregroundStyle(NativeTheme.textSecondary)
+                    .padding(.leading, 40)
+            } else {
+                ForEach(detail.comments) { comment in
+                    timelineEntry(
+                        iconSystemName: "text.bubble.fill",
+                        iconTint: NativeTheme.accent,
+                        authorText: gitHubActorSummaryText(comment.author) ?? "未知用户",
+                        headline: "commented \(gitHubRelativeDateText(comment.createdAt))",
+                        bodyText: comment.body.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty ? "空评论" : comment.body
+                    )
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var composerSection: some View {
+        switch actionMode {
+        case .pull:
+            sectionCard(title: "Add a comment") {
+                VStack(alignment: .leading, spacing: 10) {
+                    TextEditor(text: $viewModel.pullCommentDraft)
+                        .font(.callout)
+                        .frame(minHeight: 120)
+                        .padding(8)
+                        .background(NativeTheme.elevated)
+                        .clipShape(.rect(cornerRadius: 10))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(NativeTheme.border, lineWidth: 1)
+                        )
+
+                    HStack(spacing: 8) {
+                        Spacer(minLength: 0)
+                        Button("提交评论") {
+                            viewModel.addCommentToSelectedPull()
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(viewModel.isMutating || trimmedPullCommentDraft == nil)
+                    }
+                }
+            }
+        case .review:
+            sectionCard(title: "Review changes") {
+                VStack(alignment: .leading, spacing: 12) {
+                    TextEditor(text: $viewModel.reviewCommentDraft)
+                        .font(.callout)
+                        .frame(minHeight: 120)
+                        .padding(8)
+                        .background(NativeTheme.elevated)
+                        .clipShape(.rect(cornerRadius: 10))
+                        .overlay(
+                            RoundedRectangle(cornerRadius: 10)
+                                .stroke(NativeTheme.border, lineWidth: 1)
+                        )
+
+                    HStack(spacing: 8) {
+                        Button("评论") {
+                            viewModel.submitReviewForSelectedPull(event: .comment)
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(viewModel.isMutating || !canSubmitReviewComment)
+
+                        Button("通过") {
+                            viewModel.submitReviewForSelectedPull(event: .approve)
+                        }
+                        .buttonStyle(.borderedProminent)
+                        .disabled(viewModel.isMutating || !canSubmitReview)
+
+                        Button("请求修改") {
+                            viewModel.submitReviewForSelectedPull(event: .requestChanges)
+                        }
+                        .buttonStyle(.bordered)
+                        .disabled(viewModel.isMutating || !canSubmitReviewComment)
+
+                        Spacer(minLength: 0)
+                    }
+                }
+            }
+        }
+    }
+
+    private var statusSection: some View {
+        WorkspaceGitHubDetailSidebarSection(title: "Status") {
+            VStack(alignment: .leading, spacing: 12) {
+                pullStateBadge
+
+                if detail.reviewDecision != .none {
+                    inlineBadge(
+                        title: gitHubReviewDecisionTitle(detail.reviewDecision),
+                        tint: NativeTheme.accent
+                    )
+                }
+
+                if actionMode == .pull, canMergePull {
+                    Button("Merge") {
+                        viewModel.mergeSelectedPull()
                     }
                     .buttonStyle(.borderedProminent)
                     .disabled(viewModel.isMutating)
-
-                    if canMergePull {
-                        Button("Merge") {
-                            viewModel.mergeSelectedPull()
-                        }
-                        .buttonStyle(.bordered)
-                        .disabled(viewModel.isMutating)
-                    }
                 }
 
-                HStack(spacing: 8) {
-                    switch detail.state {
-                    case .open:
-                        Button("关闭 PR", role: .destructive) {
-                            viewModel.closeSelectedPull()
-                        }
-                        .buttonStyle(.bordered)
-                        .disabled(viewModel.isMutating)
-                    case .closed:
-                        Button("重新打开 PR") {
-                            viewModel.reopenSelectedPull()
-                        }
-                        .buttonStyle(.bordered)
-                        .disabled(viewModel.isMutating)
-                    case .merged, .unknown:
-                        EmptyView()
-                    }
-                    Spacer(minLength: 0)
-                }
-            }
-        }
-    }
-
-    private var pullCommentSection: some View {
-        sectionCard(title: "新增评论") {
-            VStack(alignment: .leading, spacing: 8) {
-                TextEditor(text: $viewModel.pullCommentDraft)
-                    .font(.callout)
-                    .frame(minHeight: 108)
-                    .padding(8)
-                    .background(NativeTheme.elevated)
-                    .clipShape(.rect(cornerRadius: 10))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 10)
-                            .stroke(NativeTheme.border, lineWidth: 1)
-                    )
-
-                HStack(spacing: 8) {
-                    Spacer(minLength: 0)
-                    Button("提交评论") {
-                        viewModel.addCommentToSelectedPull()
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(viewModel.isMutating || viewModel.pullCommentDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty)
-                }
-            }
-        }
-    }
-
-    private var reviewActionsSection: some View {
-        sectionCard(title: "Review Actions") {
-            VStack(alignment: .leading, spacing: 12) {
-                TextEditor(text: $viewModel.reviewCommentDraft)
-                    .font(.callout)
-                    .frame(minHeight: 108)
-                    .padding(8)
-                    .background(NativeTheme.elevated)
-                    .clipShape(.rect(cornerRadius: 10))
-                    .overlay(
-                        RoundedRectangle(cornerRadius: 10)
-                            .stroke(NativeTheme.border, lineWidth: 1)
-                    )
-
-                HStack(spacing: 8) {
-                    Button("评论") {
-                        viewModel.submitReviewForSelectedPull(event: .comment)
+                switch detail.state {
+                case .open:
+                    Button("关闭 PR", role: .destructive) {
+                        viewModel.closeSelectedPull()
                     }
                     .buttonStyle(.bordered)
-                    .disabled(viewModel.isMutating || !canSubmitReviewComment)
-
-                    Button("通过") {
-                        viewModel.submitReviewForSelectedPull(event: .approve)
-                    }
-                    .buttonStyle(.borderedProminent)
-                    .disabled(viewModel.isMutating || !canSubmitReview)
-
-                    Button("请求修改") {
-                        viewModel.submitReviewForSelectedPull(event: .requestChanges)
+                    .disabled(viewModel.isMutating)
+                case .closed:
+                    Button("重新打开 PR") {
+                        viewModel.reopenSelectedPull()
                     }
                     .buttonStyle(.bordered)
-                    .disabled(viewModel.isMutating || !canSubmitReviewComment)
+                    .disabled(viewModel.isMutating)
+                case .merged, .unknown:
+                    EmptyView()
                 }
             }
         }
     }
 
-    private var metrics: some View {
-        HStack(spacing: 10) {
-            metricCard("Files", value: "\(detail.changedFiles)")
-            metricCard("Commits", value: "\(detail.commitCount)")
-            metricCard("Comments", value: "\(detail.commentsCount)")
-            metricCard("State", value: gitHubPullStateTitle(detail.state, isDraft: detail.isDraft))
-        }
-    }
-
-    private func metricCard(_ title: String, value: String) -> some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Text(title)
-                .font(.caption)
-                .foregroundStyle(NativeTheme.textSecondary)
-            Text(value)
-                .font(.headline.weight(.semibold))
-                .foregroundStyle(NativeTheme.textPrimary)
-        }
-        .padding(12)
-        .frame(maxWidth: .infinity, alignment: .leading)
-        .background(NativeTheme.surface)
-        .overlay(
-            RoundedRectangle(cornerRadius: 12)
-                .stroke(NativeTheme.border, lineWidth: 1)
-        )
-        .clipShape(.rect(cornerRadius: 12))
-    }
-
-    private var bodySection: some View {
-        sectionCard(title: "Description") {
-            if (detail.body ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
-                Text("暂无描述")
-                    .font(.callout)
+    private var developmentSection: some View {
+        WorkspaceGitHubDetailSidebarSection(title: "Development") {
+            VStack(alignment: .leading, spacing: 10) {
+                Text("源分支")
+                    .font(.caption.weight(.semibold))
                     .foregroundStyle(NativeTheme.textSecondary)
-            } else {
-                Text(detail.body ?? "")
-                    .font(.callout)
+                Text(detail.headRefName)
+                    .font(.callout.monospaced())
                     .foregroundStyle(NativeTheme.textPrimary)
                     .textSelection(.enabled)
-                    .frame(maxWidth: .infinity, alignment: .leading)
+
+                Text("目标分支")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(NativeTheme.textSecondary)
+                Text(detail.baseRefName)
+                    .font(.callout.monospaced())
+                    .foregroundStyle(NativeTheme.textPrimary)
+                    .textSelection(.enabled)
+
+                Button("Checkout 分支") {
+                    viewModel.checkoutSelectedPullBranch()
+                }
+                .buttonStyle(.bordered)
+                .disabled(viewModel.isMutating)
             }
         }
     }
 
-    private var commentsSection: some View {
-        sectionCard(title: "Comments") {
-            if detail.comments.isEmpty {
-                Text("暂无评论")
-                    .font(.callout)
-                    .foregroundStyle(NativeTheme.textSecondary)
-            } else {
-                VStack(alignment: .leading, spacing: 12) {
-                    ForEach(detail.comments) { comment in
-                        VStack(alignment: .leading, spacing: 6) {
-                            HStack(spacing: 8) {
-                                Text(comment.author?.displayName ?? "Unknown")
-                                    .font(.caption.weight(.semibold))
-                                    .foregroundStyle(NativeTheme.textPrimary)
-                                Text(gitHubRelativeDateText(comment.createdAt))
-                                    .font(.caption)
-                                    .foregroundStyle(NativeTheme.textSecondary)
-                            }
-                            Text(comment.body)
-                                .font(.callout)
-                                .foregroundStyle(NativeTheme.textPrimary)
-                                .textSelection(.enabled)
-                        }
-                        .padding(12)
-                        .frame(maxWidth: .infinity, alignment: .leading)
-                        .background(NativeTheme.elevated)
-                        .overlay(
-                            RoundedRectangle(cornerRadius: 12)
-                                .stroke(NativeTheme.border, lineWidth: 1)
-                        )
-                        .clipShape(.rect(cornerRadius: 12))
-                    }
-                }
+    private var pullStateBadge: some View {
+        let tint = gitHubPullStateColor(detail.state, isDraft: detail.isDraft)
+        return HStack(spacing: 6) {
+            Image(systemName: gitHubPullStateSymbolName(detail.state, isDraft: detail.isDraft))
+                .font(.system(size: 12, weight: .semibold))
+            Text(gitHubPullStateTitle(detail.state, isDraft: detail.isDraft))
+                .font(.caption.weight(.semibold))
+        }
+        .foregroundStyle(tint)
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(tint.opacity(0.12))
+        .overlay(
+            Capsule()
+                .stroke(tint.opacity(0.32), lineWidth: 1)
+        )
+        .clipShape(.capsule)
+    }
+
+    private var branchSummary: String {
+        "\(detail.headRefName) -> \(detail.baseRefName)"
+    }
+
+    private var pullActivitySummary: String {
+        let authorText = gitHubActorSummaryText(detail.author) ?? "未知用户"
+        switch detail.state {
+        case .open:
+            if detail.isDraft {
+                return "\(authorText) opened a draft pull request \(gitHubRelativeDateText(detail.createdAt)) · \(detail.commentsCount) comments"
             }
+            return "\(authorText) opened this pull request \(gitHubRelativeDateText(detail.createdAt)) · \(detail.commentsCount) comments"
+        case .closed:
+            return "\(authorText) closed this pull request · updated \(gitHubRelativeDateText(detail.updatedAt))"
+        case .merged:
+            if let mergedAt = detail.mergedAt {
+                let mergedByText = gitHubActorSummaryText(detail.mergedBy) ?? authorText
+                return "\(mergedByText) merged \(gitHubRelativeDateText(mergedAt)) · \(detail.commentsCount) comments"
+            }
+            return "\(authorText) merged this pull request · \(detail.commentsCount) comments"
+        case .unknown:
+            return "\(authorText) updated \(gitHubRelativeDateText(detail.updatedAt)) · \(detail.commentsCount) comments"
         }
     }
 
@@ -310,7 +348,22 @@ struct WorkspaceGitHubPullDetailView: View {
     }
 
     private var canSubmitReviewComment: Bool {
-        canSubmitReview && !viewModel.reviewCommentDraft.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty
+        canSubmitReview && trimmedReviewCommentDraft != nil
+    }
+
+    private var trimmedBodyText: String? {
+        let trimmed = detail.body?.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed?.isEmpty == false ? trimmed : nil
+    }
+
+    private var trimmedPullCommentDraft: String? {
+        let trimmed = viewModel.pullCommentDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private var trimmedReviewCommentDraft: String? {
+        let trimmed = viewModel.reviewCommentDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
     }
 
     private var actionBanner: (message: String, tint: Color)? {
@@ -336,6 +389,70 @@ struct WorkspaceGitHubPullDetailView: View {
             return true
         default:
             return false
+        }
+    }
+
+    private func inlineBadge(title: String, tint: Color) -> some View {
+        Text(title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(tint)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(tint.opacity(0.12))
+            .overlay(
+                Capsule()
+                    .stroke(tint.opacity(0.28), lineWidth: 1)
+            )
+            .clipShape(.capsule)
+    }
+
+    private func timelineEntry(
+        iconSystemName: String,
+        iconTint: Color,
+        authorText: String,
+        headline: String,
+        bodyText: String
+    ) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            ZStack {
+                Circle()
+                    .fill(iconTint.opacity(0.12))
+                    .frame(width: 28, height: 28)
+                Image(systemName: iconSystemName)
+                    .font(.system(size: 13, weight: .semibold))
+                    .foregroundStyle(iconTint)
+            }
+
+            VStack(alignment: .leading, spacing: 0) {
+                HStack(alignment: .center, spacing: 8) {
+                    Text(authorText)
+                        .font(.caption.weight(.semibold))
+                        .foregroundStyle(NativeTheme.textPrimary)
+
+                    Text(headline)
+                        .font(.caption)
+                        .foregroundStyle(NativeTheme.textSecondary)
+
+                    Spacer(minLength: 0)
+                }
+                .padding(.horizontal, 14)
+                .padding(.vertical, 10)
+                .background(NativeTheme.elevated)
+
+                Rectangle()
+                    .fill(NativeTheme.border)
+                    .frame(height: 1)
+
+                WorkspaceGitHubRenderedContentView(content: bodyText)
+                    .padding(14)
+            }
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(NativeTheme.surface)
+            .overlay(
+                RoundedRectangle(cornerRadius: 12)
+                    .stroke(NativeTheme.border, lineWidth: 1)
+            )
+            .clipShape(.rect(cornerRadius: 12))
         }
     }
 

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubPullDetailView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubPullDetailView.swift
@@ -1,0 +1,204 @@
+import AppKit
+import SwiftUI
+import DevHavenCore
+
+struct WorkspaceGitHubPullDetailView: View {
+    let detail: WorkspaceGitHubPullDetail
+    @State private var splitRatio = 0.68
+
+    var body: some View {
+        WorkspaceSplitView(
+            direction: .horizontal,
+            ratio: splitRatio,
+            onRatioChange: { splitRatio = $0 },
+            minLeadingSize: 360,
+            minTrailingSize: 220,
+            leading: {
+                ScrollView {
+                    VStack(alignment: .leading, spacing: 16) {
+                        header
+                        metrics
+                        bodySection
+                        commentsSection
+                    }
+                    .padding(16)
+                }
+                .background(NativeTheme.window)
+            },
+            trailing: {
+                WorkspaceGitHubDetailSidebarView {
+                    WorkspaceGitHubDetailSidebarSection(title: "Labels") {
+                        WorkspaceGitHubLabelListView(labels: detail.labels)
+                    }
+
+                    WorkspaceGitHubDetailSidebarSection(title: "Assignees") {
+                        WorkspaceGitHubActorListView(actors: detail.assignees)
+                    }
+
+                    WorkspaceGitHubDetailSidebarSection(title: "Details") {
+                        VStack(alignment: .leading, spacing: 8) {
+                            WorkspaceGitHubMetadataRow(title: "Created", value: gitHubAbsoluteDateText(detail.createdAt))
+                            WorkspaceGitHubMetadataRow(title: "Updated", value: gitHubAbsoluteDateText(detail.updatedAt))
+                            WorkspaceGitHubMetadataRow(title: "Base", value: detail.baseRefName)
+                            WorkspaceGitHubMetadataRow(title: "Head", value: detail.headRefName)
+                            WorkspaceGitHubMetadataRow(title: "Review", value: gitHubReviewDecisionTitle(detail.reviewDecision))
+                            WorkspaceGitHubMetadataRow(title: "Merge", value: gitHubMergeStateTitle(detail.mergeStateStatus))
+                            if let mergedAt = detail.mergedAt {
+                                WorkspaceGitHubMetadataRow(title: "Merged", value: gitHubAbsoluteDateText(mergedAt))
+                            }
+                            if let milestone = detail.milestone {
+                                WorkspaceGitHubMetadataRow(title: "Milestone", value: milestone.title)
+                            }
+                        }
+                    }
+                }
+            }
+        )
+    }
+
+    private var header: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 12) {
+                Circle()
+                    .fill(gitHubPullStateColor(detail.state, isDraft: detail.isDraft))
+                    .frame(width: 12, height: 12)
+                    .padding(.top, 6)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    Text(detail.title)
+                        .font(.title3.weight(.semibold))
+                        .foregroundStyle(NativeTheme.textPrimary)
+                    Text("#\(detail.number) · \(detail.headRefName) -> \(detail.baseRefName)")
+                        .font(.callout)
+                        .foregroundStyle(NativeTheme.textSecondary)
+                    if let author = detail.author {
+                        Text("作者：\(author.login ?? author.displayName)")
+                            .font(.caption)
+                            .foregroundStyle(NativeTheme.textSecondary)
+                    }
+                }
+
+                Spacer(minLength: 0)
+
+                Button("Open in GitHub") {
+                    openURL(detail.url)
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(NativeTheme.accent)
+            }
+        }
+        .padding(14)
+        .background(NativeTheme.surface)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(NativeTheme.border, lineWidth: 1)
+        )
+        .clipShape(.rect(cornerRadius: 14))
+    }
+
+    private var metrics: some View {
+        HStack(spacing: 10) {
+            metricCard("Files", value: "\(detail.changedFiles)")
+            metricCard("Commits", value: "\(detail.commitCount)")
+            metricCard("Comments", value: "\(detail.commentsCount)")
+            metricCard("State", value: gitHubPullStateTitle(detail.state, isDraft: detail.isDraft))
+        }
+    }
+
+    private func metricCard(_ title: String, value: String) -> some View {
+        VStack(alignment: .leading, spacing: 4) {
+            Text(title)
+                .font(.caption)
+                .foregroundStyle(NativeTheme.textSecondary)
+            Text(value)
+                .font(.headline.weight(.semibold))
+                .foregroundStyle(NativeTheme.textPrimary)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(NativeTheme.surface)
+        .overlay(
+            RoundedRectangle(cornerRadius: 12)
+                .stroke(NativeTheme.border, lineWidth: 1)
+        )
+        .clipShape(.rect(cornerRadius: 12))
+    }
+
+    private var bodySection: some View {
+        VStack(alignment: .leading, spacing: 10) {
+            Text("Description")
+                .font(.headline)
+                .foregroundStyle(NativeTheme.textPrimary)
+            if (detail.body ?? "").trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                Text("暂无描述")
+                    .font(.callout)
+                    .foregroundStyle(NativeTheme.textSecondary)
+            } else {
+                Text(detail.body ?? "")
+                    .font(.callout)
+                    .foregroundStyle(NativeTheme.textPrimary)
+                    .textSelection(.enabled)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+            }
+        }
+        .padding(14)
+        .background(NativeTheme.surface)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(NativeTheme.border, lineWidth: 1)
+        )
+        .clipShape(.rect(cornerRadius: 14))
+    }
+
+    private var commentsSection: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("Comments")
+                .font(.headline)
+                .foregroundStyle(NativeTheme.textPrimary)
+            if detail.comments.isEmpty {
+                Text("暂无评论")
+                    .font(.callout)
+                    .foregroundStyle(NativeTheme.textSecondary)
+            } else {
+                ForEach(detail.comments) { comment in
+                    VStack(alignment: .leading, spacing: 6) {
+                        HStack(spacing: 8) {
+                            Text(comment.author?.displayName ?? "Unknown")
+                                .font(.caption.weight(.semibold))
+                                .foregroundStyle(NativeTheme.textPrimary)
+                            Text(gitHubRelativeDateText(comment.createdAt))
+                                .font(.caption)
+                                .foregroundStyle(NativeTheme.textSecondary)
+                        }
+                        Text(comment.body)
+                            .font(.callout)
+                            .foregroundStyle(NativeTheme.textPrimary)
+                            .textSelection(.enabled)
+                    }
+                    .padding(12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(NativeTheme.elevated)
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 12)
+                            .stroke(NativeTheme.border, lineWidth: 1)
+                    )
+                    .clipShape(.rect(cornerRadius: 12))
+                }
+            }
+        }
+        .padding(14)
+        .background(NativeTheme.surface)
+        .overlay(
+            RoundedRectangle(cornerRadius: 14)
+                .stroke(NativeTheme.border, lineWidth: 1)
+        )
+        .clipShape(.rect(cornerRadius: 14))
+    }
+
+    private func openURL(_ string: String) {
+        guard let url = URL(string: string) else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubPullsView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubPullsView.swift
@@ -23,39 +23,79 @@ struct WorkspaceGitHubPullsView: View {
     }
 
     private var listPane: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 10) {
-                if viewModel.pulls.isEmpty, !viewModel.isLoading {
-                    ContentUnavailableView(
-                        "暂无 Pull Requests",
-                        systemImage: "arrow.triangle.pull",
-                        description: Text("当前仓库没有符合条件的 Pull Request。")
-                    )
-                    .foregroundStyle(NativeTheme.textSecondary)
-                    .frame(maxWidth: .infinity, minHeight: 240)
-                } else {
-                    ForEach(viewModel.pulls) { pull in
-                        WorkspaceGitHubPullRowView(
-                            pull: pull,
-                            isSelected: viewModel.selectedPullNumber == pull.number,
-                            onSelect: { viewModel.selectPull(number: pull.number) }
+        VStack(spacing: 0) {
+            pullListHeader
+
+            Rectangle()
+                .fill(NativeTheme.border)
+                .frame(height: 1)
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    if viewModel.pulls.isEmpty, !viewModel.isLoading {
+                        ContentUnavailableView(
+                            "暂无 Pull Requests",
+                            systemImage: "arrow.triangle.pull",
+                            description: Text("当前仓库没有符合条件的 Pull Request。")
                         )
-                        .contextMenu {
-                            Button("在 GitHub 中打开") {
-                                openURL(pull.url)
+                        .foregroundStyle(NativeTheme.textSecondary)
+                        .frame(maxWidth: .infinity, minHeight: 240)
+                    } else {
+                        ForEach(viewModel.pulls) { pull in
+                            WorkspaceGitHubPullRowView(
+                                pull: pull,
+                                isSelected: viewModel.selectedPullNumber == pull.number,
+                                onSelect: { viewModel.selectPull(number: pull.number) }
+                            )
+                            .contextMenu {
+                                Button("在 GitHub 中打开") {
+                                    openURL(pull.url)
+                                }
                             }
                         }
                     }
                 }
             }
-            .padding(12)
         }
-        .background(NativeTheme.sidebar)
+        .background(NativeTheme.surface)
         .overlay {
             if viewModel.isLoading {
                 WorkspaceGitHubListLoadingOverlay(title: "正在刷新 Pull Requests…")
             }
         }
+    }
+
+    private var pullListHeader: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .center, spacing: 8) {
+                Text("Pull requests")
+                    .font(.headline)
+                    .foregroundStyle(NativeTheme.textPrimary)
+
+                Text("\(viewModel.pulls.count)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(NativeTheme.textSecondary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(NativeTheme.elevated)
+                    .clipShape(.capsule)
+
+                Spacer(minLength: 0)
+            }
+
+            HStack(spacing: 8) {
+                filterBadge(title: viewModel.pullFilter.state.title, tint: pullFilterTint)
+
+                if let searchText = trimmedPullSearchText {
+                    filterBadge(title: "搜索: \(searchText)", tint: NativeTheme.textSecondary)
+                }
+
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background(NativeTheme.sidebar)
     }
 
     @ViewBuilder
@@ -96,5 +136,37 @@ struct WorkspaceGitHubPullsView: View {
             return
         }
         NSWorkspace.shared.open(url)
+    }
+
+    private var pullFilterTint: Color {
+        switch viewModel.pullFilter.state {
+        case .open:
+            return .green
+        case .closed:
+            return .red
+        case .merged:
+            return .purple
+        case .all:
+            return NativeTheme.textSecondary
+        }
+    }
+
+    private var trimmedPullSearchText: String? {
+        let trimmed = viewModel.pullFilter.searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func filterBadge(title: String, tint: Color) -> some View {
+        Text(title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(tint)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(tint.opacity(0.12))
+            .overlay(
+                Capsule()
+                    .stroke(tint.opacity(0.28), lineWidth: 1)
+            )
+            .clipShape(.capsule)
     }
 }

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubPullsView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubPullsView.swift
@@ -74,7 +74,11 @@ struct WorkspaceGitHubPullsView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(NativeTheme.window)
         } else if let detail = viewModel.selectedPullDetail {
-            WorkspaceGitHubPullDetailView(detail: detail)
+            WorkspaceGitHubPullDetailView(
+                viewModel: viewModel,
+                detail: detail,
+                actionMode: .pull
+            )
         } else {
             ContentUnavailableView(
                 "选择一个 Pull Request",

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubPullsView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubPullsView.swift
@@ -1,0 +1,96 @@
+import AppKit
+import SwiftUI
+import DevHavenCore
+
+struct WorkspaceGitHubPullsView: View {
+    @Bindable var viewModel: WorkspaceGitHubViewModel
+    @State private var splitRatio = 0.36
+
+    var body: some View {
+        WorkspaceSplitView(
+            direction: .horizontal,
+            ratio: splitRatio,
+            onRatioChange: { splitRatio = $0 },
+            minLeadingSize: 260,
+            minTrailingSize: 320,
+            leading: {
+                listPane
+            },
+            trailing: {
+                detailPane
+            }
+        )
+    }
+
+    private var listPane: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 10) {
+                if viewModel.pulls.isEmpty, !viewModel.isLoading {
+                    ContentUnavailableView(
+                        "暂无 Pull Requests",
+                        systemImage: "arrow.triangle.pull",
+                        description: Text("当前仓库没有符合条件的 Pull Request。")
+                    )
+                    .foregroundStyle(NativeTheme.textSecondary)
+                    .frame(maxWidth: .infinity, minHeight: 240)
+                } else {
+                    ForEach(viewModel.pulls) { pull in
+                        WorkspaceGitHubPullRowView(
+                            pull: pull,
+                            isSelected: viewModel.selectedPullNumber == pull.number,
+                            onSelect: { viewModel.selectPull(number: pull.number) }
+                        )
+                        .contextMenu {
+                            Button("在 GitHub 中打开") {
+                                openURL(pull.url)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(12)
+        }
+        .background(NativeTheme.sidebar)
+        .overlay {
+            if viewModel.isLoading {
+                WorkspaceGitHubListLoadingOverlay(title: "正在刷新 Pull Requests…")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var detailPane: some View {
+        if viewModel.isLoadingDetail {
+            ProgressView("正在加载 PR 详情…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(NativeTheme.window)
+        } else if let detailErrorMessage = viewModel.detailErrorMessage {
+            ContentUnavailableView(
+                "PR 详情加载失败",
+                systemImage: "exclamationmark.triangle",
+                description: Text(detailErrorMessage)
+            )
+            .foregroundStyle(NativeTheme.textSecondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(NativeTheme.window)
+        } else if let detail = viewModel.selectedPullDetail {
+            WorkspaceGitHubPullDetailView(detail: detail)
+        } else {
+            ContentUnavailableView(
+                "选择一个 Pull Request",
+                systemImage: "arrow.triangle.pull",
+                description: Text("从左侧列表中选择一个 PR 查看详情。")
+            )
+            .foregroundStyle(NativeTheme.textSecondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(NativeTheme.window)
+        }
+    }
+
+    private func openURL(_ string: String) {
+        guard let url = URL(string: string) else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubRenderedContentView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubRenderedContentView.swift
@@ -1,0 +1,652 @@
+import AppKit
+import SwiftUI
+import WebKit
+
+struct WorkspaceGitHubRenderedContentView: View {
+    let content: String
+    @State private var contentHeight: CGFloat = 120
+
+    var body: some View {
+        WorkspaceGitHubMarkdownWebView(
+            html: WorkspaceGitHubMarkdownHTMLRenderer.documentHTML(for: content),
+            contentHeight: $contentHeight
+        )
+        .frame(height: max(120, contentHeight))
+        .frame(maxWidth: .infinity, alignment: .leading)
+    }
+}
+
+private struct WorkspaceGitHubMarkdownWebView: NSViewRepresentable {
+    let html: String
+    @Binding var contentHeight: CGFloat
+
+    func makeCoordinator() -> Coordinator {
+        Coordinator(contentHeight: $contentHeight)
+    }
+
+    func makeNSView(context: Context) -> WKWebView {
+        let controller = WKUserContentController()
+        controller.add(context.coordinator, name: Coordinator.heightMessageName)
+        controller.addUserScript(WKUserScript(
+            source: Coordinator.heightObserverScript,
+            injectionTime: .atDocumentEnd,
+            forMainFrameOnly: true
+        ))
+
+        let configuration = WKWebViewConfiguration()
+        configuration.userContentController = controller
+
+        let webView = WorkspaceGitHubMarkdownNativeWebView(frame: .zero, configuration: configuration)
+        webView.navigationDelegate = context.coordinator
+        webView.setValue(false, forKey: "drawsBackground")
+        webView.allowsBackForwardNavigationGestures = false
+        webView.allowsMagnification = false
+        context.coordinator.update(html: html, on: webView)
+        return webView
+    }
+
+    func updateNSView(_ nsView: WKWebView, context: Context) {
+        context.coordinator.update(html: html, on: nsView)
+    }
+
+    static func dismantleNSView(_ nsView: WKWebView, coordinator: Coordinator) {
+        nsView.navigationDelegate = nil
+        nsView.configuration.userContentController.removeScriptMessageHandler(forName: Coordinator.heightMessageName)
+    }
+
+    final class Coordinator: NSObject, WKNavigationDelegate, WKScriptMessageHandler {
+        static let heightMessageName = "devhavenGitHubHeight"
+        static let heightObserverScript = """
+        (function() {
+          function postHeight() {
+            var body = document.body;
+            var doc = document.documentElement;
+            if (!body || !doc || !window.webkit || !window.webkit.messageHandlers || !window.webkit.messageHandlers.\(heightMessageName)) {
+              return;
+            }
+            var height = Math.max(
+              body.scrollHeight,
+              body.offsetHeight,
+              doc.clientHeight,
+              doc.scrollHeight,
+              doc.offsetHeight
+            );
+            window.webkit.messageHandlers.\(heightMessageName).postMessage(height);
+          }
+          window.addEventListener('load', postHeight);
+          window.addEventListener('resize', postHeight);
+          document.addEventListener('DOMContentLoaded', postHeight);
+          if (window.ResizeObserver) {
+            var observer = new ResizeObserver(function() { postHeight(); });
+            observer.observe(document.documentElement);
+          }
+          Array.prototype.forEach.call(document.images, function(image) {
+            if (!image.complete) {
+              image.addEventListener('load', postHeight);
+              image.addEventListener('error', postHeight);
+            }
+          });
+          setTimeout(postHeight, 0);
+          setTimeout(postHeight, 120);
+          setTimeout(postHeight, 400);
+        })();
+        """
+
+        @Binding private var contentHeight: CGFloat
+        private var lastHTML: String?
+
+        init(contentHeight: Binding<CGFloat>) {
+            _contentHeight = contentHeight
+        }
+
+        func update(html: String, on webView: WKWebView) {
+            guard lastHTML != html else {
+                evaluateHeight(on: webView)
+                return
+            }
+            lastHTML = html
+            configureEmbeddedScrollViewIfNeeded(in: webView)
+            webView.loadHTMLString(html, baseURL: URL(string: "https://github.com"))
+        }
+
+        func webView(_ webView: WKWebView, didFinish navigation: WKNavigation!) {
+            configureEmbeddedScrollViewIfNeeded(in: webView)
+            evaluateHeight(on: webView)
+        }
+
+        @MainActor
+        func webView(
+            _ webView: WKWebView,
+            decidePolicyFor navigationAction: WKNavigationAction,
+            decisionHandler: @escaping @MainActor @Sendable (WKNavigationActionPolicy) -> Void
+        ) {
+            if navigationAction.navigationType == .linkActivated,
+               let url = navigationAction.request.url {
+                NSWorkspace.shared.open(url)
+                decisionHandler(.cancel)
+                return
+            }
+            decisionHandler(.allow)
+        }
+
+        func userContentController(_ userContentController: WKUserContentController, didReceive message: WKScriptMessage) {
+            guard message.name == Self.heightMessageName else {
+                return
+            }
+            let resolvedHeight: CGFloat?
+            if let value = message.body as? Double {
+                resolvedHeight = CGFloat(value)
+            } else if let value = message.body as? Int {
+                resolvedHeight = CGFloat(value)
+            } else {
+                resolvedHeight = nil
+            }
+            guard let resolvedHeight else {
+                return
+            }
+            DispatchQueue.main.async {
+                self.contentHeight = max(120, resolvedHeight)
+            }
+        }
+
+        private func evaluateHeight(on webView: WKWebView) {
+            webView.evaluateJavaScript(
+                "Math.max(document.body.scrollHeight, document.documentElement.scrollHeight, document.body.offsetHeight, document.documentElement.offsetHeight);"
+            ) { [weak self] result, _ in
+                guard let self else {
+                    return
+                }
+                let resolvedHeight: CGFloat?
+                if let value = result as? Double {
+                    resolvedHeight = CGFloat(value)
+                } else if let value = result as? Int {
+                    resolvedHeight = CGFloat(value)
+                } else {
+                    resolvedHeight = nil
+                }
+                guard let resolvedHeight else {
+                    return
+                }
+                DispatchQueue.main.async {
+                    self.contentHeight = max(120, resolvedHeight)
+                }
+            }
+        }
+
+        private func configureEmbeddedScrollViewIfNeeded(in webView: WKWebView) {
+            for subview in webView.subviews {
+                guard let scrollView = subview as? NSScrollView else {
+                    continue
+                }
+                scrollView.hasVerticalScroller = false
+                scrollView.hasHorizontalScroller = false
+                scrollView.autohidesScrollers = true
+                scrollView.drawsBackground = false
+                scrollView.borderType = .noBorder
+                scrollView.verticalScrollElasticity = .none
+                scrollView.horizontalScrollElasticity = .none
+            }
+        }
+    }
+}
+
+private final class WorkspaceGitHubMarkdownNativeWebView: WKWebView {
+    override func scrollWheel(with event: NSEvent) {
+        if let outerScrollView = nearestAncestorScrollView() {
+            outerScrollView.scrollWheel(with: event)
+            return
+        }
+        super.scrollWheel(with: event)
+    }
+
+    private func nearestAncestorScrollView() -> NSScrollView? {
+        var candidate: NSView? = superview
+        while let current = candidate {
+            if let scrollView = current as? NSScrollView {
+                return scrollView
+            }
+            candidate = current.superview
+        }
+        return nil
+    }
+}
+
+private enum WorkspaceGitHubMarkdownHTMLRenderer {
+    private enum ListKind {
+        case unordered
+        case ordered
+
+        var tagName: String {
+            switch self {
+            case .unordered:
+                return "ul"
+            case .ordered:
+                return "ol"
+            }
+        }
+    }
+
+    static func documentHTML(for markdown: String) -> String {
+        let body = renderBlocks(markdown)
+        return """
+        <!doctype html>
+        <html>
+        <head>
+          <meta charset="utf-8">
+          <meta name="viewport" content="width=device-width, initial-scale=1">
+          <style>
+            :root {
+              color-scheme: dark;
+              --bg: transparent;
+              --fg: #e6edf3;
+              --muted: #8b949e;
+              --border: #30363d;
+              --accent: #58a6ff;
+              --canvas-subtle: #161b22;
+              --canvas-default: #0d1117;
+              --success: #3fb950;
+            }
+            html, body {
+              margin: 0;
+              padding: 0;
+              background: var(--bg);
+              color: var(--fg);
+              font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+              font-size: 14px;
+              line-height: 1.6;
+              overflow: hidden;
+            }
+            .markdown-body {
+              color: var(--fg);
+              background: transparent;
+              word-break: break-word;
+              overflow-wrap: anywhere;
+              overflow: hidden;
+            }
+            .markdown-body > *:first-child { margin-top: 0 !important; }
+            .markdown-body > *:last-child { margin-bottom: 0 !important; }
+            .markdown-body h1,
+            .markdown-body h2,
+            .markdown-body h3,
+            .markdown-body h4,
+            .markdown-body h5,
+            .markdown-body h6 {
+              margin: 24px 0 16px;
+              font-weight: 600;
+              line-height: 1.25;
+            }
+            .markdown-body h1,
+            .markdown-body h2 {
+              padding-bottom: 0.3em;
+              border-bottom: 1px solid var(--border);
+            }
+            .markdown-body h1 { font-size: 2em; }
+            .markdown-body h2 { font-size: 1.5em; }
+            .markdown-body h3 { font-size: 1.25em; }
+            .markdown-body h4 { font-size: 1em; }
+            .markdown-body p,
+            .markdown-body ul,
+            .markdown-body ol,
+            .markdown-body pre,
+            .markdown-body blockquote,
+            .markdown-body table {
+              margin: 0 0 16px;
+            }
+            .markdown-body ul,
+            .markdown-body ol {
+              padding-left: 2em;
+            }
+            .markdown-body li + li {
+              margin-top: 0.25em;
+            }
+            .markdown-body blockquote {
+              margin-left: 0;
+              padding: 0 1em;
+              color: var(--muted);
+              border-left: 0.25em solid var(--border);
+            }
+            .markdown-body code {
+              font-family: ui-monospace, SFMono-Regular, SF Mono, Menlo, Consolas, monospace;
+              font-size: 85%;
+              padding: 0.2em 0.4em;
+              background: rgba(110, 118, 129, 0.25);
+              border-radius: 6px;
+            }
+            .markdown-body pre {
+              padding: 16px;
+              overflow: auto;
+              background: var(--canvas-subtle);
+              border: 1px solid var(--border);
+              border-radius: 10px;
+            }
+            .markdown-body pre code {
+              padding: 0;
+              background: transparent;
+              border-radius: 0;
+            }
+            .markdown-body a {
+              color: var(--accent);
+              text-decoration: none;
+            }
+            .markdown-body a:hover {
+              text-decoration: underline;
+            }
+            .markdown-body hr {
+              height: 1px;
+              margin: 24px 0;
+              background: var(--border);
+              border: 0;
+            }
+            .markdown-body img {
+              display: block;
+              max-width: 100%;
+              height: auto;
+              margin: 12px 0;
+              border-radius: 8px;
+              border: 1px solid var(--border);
+              background: var(--canvas-default);
+            }
+          </style>
+        </head>
+        <body>
+          <div class="markdown-body">\(body)</div>
+        </body>
+        </html>
+        """
+    }
+
+    private static func renderBlocks(_ markdown: String) -> String {
+        let lines = markdown
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .components(separatedBy: "\n")
+
+        var htmlBlocks: [String] = []
+        var paragraphLines: [String] = []
+        var listKind: ListKind?
+        var listItems: [String] = []
+        var codeBlockLines: [String] = []
+        var codeBlockLanguage: String?
+        var inCodeBlock = false
+        var blockquoteLines: [String] = []
+
+        func flushParagraph() {
+            guard !paragraphLines.isEmpty else {
+                return
+            }
+            let paragraph = paragraphLines.joined(separator: " ")
+            htmlBlocks.append("<p>\(renderInline(paragraph))</p>")
+            paragraphLines.removeAll()
+        }
+
+        func flushList() {
+            guard let listKind, !listItems.isEmpty else {
+                listItems.removeAll()
+                return
+            }
+            let items = listItems.map { "<li>\($0)</li>" }.joined()
+            htmlBlocks.append("<\(listKind.tagName)>\(items)</\(listKind.tagName)>")
+            selfResetList()
+        }
+
+        func selfResetList() {
+            listKind = nil
+            listItems.removeAll()
+        }
+
+        func flushCodeBlock() {
+            guard inCodeBlock else {
+                return
+            }
+            let languageClass: String
+            if let codeBlockLanguage,
+               !codeBlockLanguage.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                languageClass = " class=\"language-\(escapeHTMLAttribute(codeBlockLanguage))\""
+            } else {
+                languageClass = ""
+            }
+            let code = escapeHTML(codeBlockLines.joined(separator: "\n"))
+            htmlBlocks.append("<pre><code\(languageClass)>\(code)</code></pre>")
+            inCodeBlock = false
+            codeBlockLines.removeAll()
+            codeBlockLanguage = nil
+        }
+
+        func flushBlockquote() {
+            guard !blockquoteLines.isEmpty else {
+                return
+            }
+            let quoteContent = renderBlocks(blockquoteLines.joined(separator: "\n"))
+            htmlBlocks.append("<blockquote>\(quoteContent)</blockquote>")
+            blockquoteLines.removeAll()
+        }
+
+        for line in lines {
+            let trimmed = line.trimmingCharacters(in: .whitespaces)
+
+            if inCodeBlock {
+                if trimmed.hasPrefix("```") {
+                    flushCodeBlock()
+                } else {
+                    codeBlockLines.append(line)
+                }
+                continue
+            }
+
+            if trimmed.hasPrefix("```") {
+                flushParagraph()
+                flushList()
+                flushBlockquote()
+                inCodeBlock = true
+                let language = trimmed.dropFirst(3).trimmingCharacters(in: .whitespaces)
+                codeBlockLanguage = language.isEmpty ? nil : language
+                continue
+            }
+
+            if trimmed.isEmpty {
+                flushParagraph()
+                flushList()
+                flushBlockquote()
+                continue
+            }
+
+            if let quoteLine = capture(in: line, pattern: #"^\s*>\s?(.*)$"#, group: 1) {
+                flushParagraph()
+                flushList()
+                blockquoteLines.append(quoteLine)
+                continue
+            } else {
+                flushBlockquote()
+            }
+
+            if isRawHTMLBlock(trimmed) {
+                flushParagraph()
+                flushList()
+                htmlBlocks.append(trimmed)
+                continue
+            }
+
+            if isHorizontalRule(trimmed) {
+                flushParagraph()
+                flushList()
+                htmlBlocks.append("<hr />")
+                continue
+            }
+
+            if let headingHashes = capture(in: line, pattern: #"^\s*(#{1,6})\s+(.+)$"#, group: 1),
+               let headingText = capture(in: line, pattern: #"^\s*(#{1,6})\s+(.+)$"#, group: 2) {
+                flushParagraph()
+                flushList()
+                let level = min(6, headingHashes.count)
+                htmlBlocks.append("<h\(level)>\(renderInline(headingText))</h\(level)>")
+                continue
+            }
+
+            if let unorderedItem = capture(in: line, pattern: #"^\s*[-*+]\s+(.+)$"#, group: 1) {
+                flushParagraph()
+                if listKind != .unordered {
+                    flushList()
+                    listKind = .unordered
+                }
+                listItems.append(renderInline(unorderedItem))
+                continue
+            }
+
+            if let orderedItem = capture(in: line, pattern: #"^\s*\d+\.\s+(.+)$"#, group: 1) {
+                flushParagraph()
+                if listKind != .ordered {
+                    flushList()
+                    listKind = .ordered
+                }
+                listItems.append(renderInline(orderedItem))
+                continue
+            }
+
+            flushList()
+            paragraphLines.append(trimmed)
+        }
+
+        flushParagraph()
+        flushList()
+        flushBlockquote()
+        flushCodeBlock()
+
+        return htmlBlocks.joined(separator: "\n")
+    }
+
+    private static func renderInline(_ text: String) -> String {
+        if text.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return ""
+        }
+
+        var working = text
+        var placeholders: [String: String] = [:]
+        var placeholderIndex = 0
+
+        func makePlaceholder(for html: String) -> String {
+            let token = "DEVHAVENPLACEHOLDERTOKEN\(placeholderIndex)END"
+            placeholderIndex += 1
+            placeholders[token] = html
+            return token
+        }
+
+        working = replace(
+            in: working,
+            pattern: #"!\[([^\]]*)\]\((https?://[^\s)]+)(?:\s+"[^"]*")?\)"#
+        ) { groups in
+            let alt = escapeHTMLAttribute(groups[0])
+            let url = escapeHTMLAttribute(groups[1])
+            return makePlaceholder(for: #"<img src="\#(url)" alt="\#(alt)" />"#)
+        }
+
+        working = replace(
+            in: working,
+            pattern: #"\[([^\]]+)\]\((https?://[^\s)]+)(?:\s+"[^"]*")?\)"#
+        ) { groups in
+            let title = escapeHTML(groups[0])
+            let url = escapeHTMLAttribute(groups[1])
+            return makePlaceholder(for: #"<a href="\#(url)">\#(title)</a>"#)
+        }
+
+        working = replace(
+            in: working,
+            pattern: #"`([^`]+)`"#
+        ) { groups in
+            makePlaceholder(for: "<code>\(escapeHTML(groups[0]))</code>")
+        }
+
+        working = escapeHTML(working)
+
+        working = replaceSimple(in: working, pattern: #"\*\*([^*]+)\*\*"#, template: "<strong>$1</strong>")
+        working = replaceSimple(in: working, pattern: #"__([^_]+)__"#, template: "<strong>$1</strong>")
+        working = replaceSimple(in: working, pattern: #"~~([^~]+)~~"#, template: "<del>$1</del>")
+        working = replaceSimple(in: working, pattern: #"(?<!\*)\*([^*]+)\*(?!\*)"#, template: "<em>$1</em>")
+        working = replaceSimple(in: working, pattern: #"(?<!_)_([^_]+)_(?!_)"#, template: "<em>$1</em>")
+
+        for token in placeholders.keys.sorted(by: { $0.count > $1.count }) {
+            if let html = placeholders[token] {
+                working = working.replacingOccurrences(of: token, with: html)
+            }
+        }
+
+        return working
+    }
+
+    private static func replace(
+        in text: String,
+        pattern: String,
+        transform: ([String]) -> String
+    ) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
+            return text
+        }
+        let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
+        let matches = regex.matches(in: text, options: [], range: nsRange)
+        guard !matches.isEmpty else {
+            return text
+        }
+
+        var result = text
+        for match in matches.reversed() {
+            guard let range = Range(match.range, in: result) else {
+                continue
+            }
+            let groups: [String] = (1..<match.numberOfRanges).compactMap { index in
+                guard let groupRange = Range(match.range(at: index), in: result) else {
+                    return nil
+                }
+                return String(result[groupRange])
+            }
+            result.replaceSubrange(range, with: transform(groups))
+        }
+        return result
+    }
+
+    private static func replaceSimple(in text: String, pattern: String, template: String) -> String {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
+            return text
+        }
+        let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
+        return regex.stringByReplacingMatches(in: text, options: [], range: nsRange, withTemplate: template)
+    }
+
+    private static func capture(in text: String, pattern: String, group: Int) -> String? {
+        guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
+            return nil
+        }
+        let nsRange = NSRange(text.startIndex..<text.endIndex, in: text)
+        guard let match = regex.firstMatch(in: text, options: [], range: nsRange),
+              let range = Range(match.range(at: group), in: text) else {
+            return nil
+        }
+        return String(text[range])
+    }
+
+    private static func isRawHTMLBlock(_ text: String) -> Bool {
+        text.hasPrefix("<img")
+            || text.hasPrefix("<p")
+            || text.hasPrefix("<div")
+            || text.hasPrefix("<table")
+            || text.hasPrefix("<details")
+            || text.hasPrefix("<summary")
+            || text.hasPrefix("<br")
+    }
+
+    private static func isHorizontalRule(_ text: String) -> Bool {
+        let compact = text.replacingOccurrences(of: " ", with: "")
+        return compact == "---" || compact == "***" || compact == "___"
+    }
+
+    private static func escapeHTML(_ text: String) -> String {
+        text
+            .replacingOccurrences(of: "&", with: "&amp;")
+            .replacingOccurrences(of: "<", with: "&lt;")
+            .replacingOccurrences(of: ">", with: "&gt;")
+    }
+
+    private static func escapeHTMLAttribute(_ text: String) -> String {
+        escapeHTML(text)
+            .replacingOccurrences(of: "\"", with: "&quot;")
+            .replacingOccurrences(of: "'", with: "&#39;")
+    }
+}

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubReviewsView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubReviewsView.swift
@@ -74,7 +74,11 @@ struct WorkspaceGitHubReviewsView: View {
             .frame(maxWidth: .infinity, maxHeight: .infinity)
             .background(NativeTheme.window)
         } else if let detail = viewModel.selectedPullDetail {
-            WorkspaceGitHubPullDetailView(detail: detail)
+            WorkspaceGitHubPullDetailView(
+                viewModel: viewModel,
+                detail: detail,
+                actionMode: .review
+            )
         } else {
             ContentUnavailableView(
                 "选择一个 Review",

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubReviewsView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubReviewsView.swift
@@ -1,0 +1,96 @@
+import AppKit
+import SwiftUI
+import DevHavenCore
+
+struct WorkspaceGitHubReviewsView: View {
+    @Bindable var viewModel: WorkspaceGitHubViewModel
+    @State private var splitRatio = 0.36
+
+    var body: some View {
+        WorkspaceSplitView(
+            direction: .horizontal,
+            ratio: splitRatio,
+            onRatioChange: { splitRatio = $0 },
+            minLeadingSize: 260,
+            minTrailingSize: 320,
+            leading: {
+                listPane
+            },
+            trailing: {
+                detailPane
+            }
+        )
+    }
+
+    private var listPane: some View {
+        ScrollView {
+            LazyVStack(alignment: .leading, spacing: 10) {
+                if viewModel.reviewRequests.isEmpty, !viewModel.isLoading {
+                    ContentUnavailableView(
+                        "暂无 Reviews",
+                        systemImage: "person.badge.key",
+                        description: Text("当前仓库没有请求你评审的 Pull Request。")
+                    )
+                    .foregroundStyle(NativeTheme.textSecondary)
+                    .frame(maxWidth: .infinity, minHeight: 240)
+                } else {
+                    ForEach(viewModel.reviewRequests) { review in
+                        WorkspaceGitHubReviewRowView(
+                            review: review,
+                            isSelected: viewModel.selectedPullNumber == review.number,
+                            onSelect: { viewModel.selectPull(number: review.number) }
+                        )
+                        .contextMenu {
+                            Button("在 GitHub 中打开") {
+                                openURL(review.url)
+                            }
+                        }
+                    }
+                }
+            }
+            .padding(12)
+        }
+        .background(NativeTheme.sidebar)
+        .overlay {
+            if viewModel.isLoading {
+                WorkspaceGitHubListLoadingOverlay(title: "正在刷新 Reviews…")
+            }
+        }
+    }
+
+    @ViewBuilder
+    private var detailPane: some View {
+        if viewModel.isLoadingDetail {
+            ProgressView("正在加载 Review 详情…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+                .background(NativeTheme.window)
+        } else if let detailErrorMessage = viewModel.detailErrorMessage {
+            ContentUnavailableView(
+                "Review 详情加载失败",
+                systemImage: "exclamationmark.triangle",
+                description: Text(detailErrorMessage)
+            )
+            .foregroundStyle(NativeTheme.textSecondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(NativeTheme.window)
+        } else if let detail = viewModel.selectedPullDetail {
+            WorkspaceGitHubPullDetailView(detail: detail)
+        } else {
+            ContentUnavailableView(
+                "选择一个 Review",
+                systemImage: "person.badge.key",
+                description: Text("从左侧列表中选择一个待评审的 PR。")
+            )
+            .foregroundStyle(NativeTheme.textSecondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+            .background(NativeTheme.window)
+        }
+    }
+
+    private func openURL(_ string: String) {
+        guard let url = URL(string: string) else {
+            return
+        }
+        NSWorkspace.shared.open(url)
+    }
+}

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubReviewsView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubReviewsView.swift
@@ -23,39 +23,80 @@ struct WorkspaceGitHubReviewsView: View {
     }
 
     private var listPane: some View {
-        ScrollView {
-            LazyVStack(alignment: .leading, spacing: 10) {
-                if viewModel.reviewRequests.isEmpty, !viewModel.isLoading {
-                    ContentUnavailableView(
-                        "暂无 Reviews",
-                        systemImage: "person.badge.key",
-                        description: Text("当前仓库没有请求你评审的 Pull Request。")
-                    )
-                    .foregroundStyle(NativeTheme.textSecondary)
-                    .frame(maxWidth: .infinity, minHeight: 240)
-                } else {
-                    ForEach(viewModel.reviewRequests) { review in
-                        WorkspaceGitHubReviewRowView(
-                            review: review,
-                            isSelected: viewModel.selectedPullNumber == review.number,
-                            onSelect: { viewModel.selectPull(number: review.number) }
+        VStack(spacing: 0) {
+            reviewListHeader
+
+            Rectangle()
+                .fill(NativeTheme.border)
+                .frame(height: 1)
+
+            ScrollView {
+                LazyVStack(alignment: .leading, spacing: 0) {
+                    if viewModel.reviewRequests.isEmpty, !viewModel.isLoading {
+                        ContentUnavailableView(
+                            "暂无 Reviews",
+                            systemImage: "person.badge.key",
+                            description: Text("当前仓库没有请求你评审的 Pull Request。")
                         )
-                        .contextMenu {
-                            Button("在 GitHub 中打开") {
-                                openURL(review.url)
+                        .foregroundStyle(NativeTheme.textSecondary)
+                        .frame(maxWidth: .infinity, minHeight: 240)
+                    } else {
+                        ForEach(viewModel.reviewRequests) { review in
+                            WorkspaceGitHubReviewRowView(
+                                review: review,
+                                isSelected: viewModel.selectedPullNumber == review.number,
+                                onSelect: { viewModel.selectPull(number: review.number) }
+                            )
+                            .contextMenu {
+                                Button("在 GitHub 中打开") {
+                                    openURL(review.url)
+                                }
                             }
                         }
                     }
                 }
             }
-            .padding(12)
         }
-        .background(NativeTheme.sidebar)
+        .background(NativeTheme.surface)
         .overlay {
             if viewModel.isLoading {
                 WorkspaceGitHubListLoadingOverlay(title: "正在刷新 Reviews…")
             }
         }
+    }
+
+    private var reviewListHeader: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack(alignment: .center, spacing: 8) {
+                Text("Reviews")
+                    .font(.headline)
+                    .foregroundStyle(NativeTheme.textPrimary)
+
+                Text("\(viewModel.reviewRequests.count)")
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(NativeTheme.textSecondary)
+                    .padding(.horizontal, 8)
+                    .padding(.vertical, 4)
+                    .background(NativeTheme.elevated)
+                    .clipShape(.capsule)
+
+                Spacer(minLength: 0)
+            }
+
+            HStack(spacing: 8) {
+                filterBadge(title: viewModel.reviewFilter.state.title, tint: reviewFilterTint)
+                filterBadge(title: viewModel.reviewFilter.scope.title, tint: NativeTheme.textSecondary)
+
+                if let searchText = trimmedReviewSearchText {
+                    filterBadge(title: "搜索: \(searchText)", tint: NativeTheme.textSecondary)
+                }
+
+                Spacer(minLength: 0)
+            }
+        }
+        .padding(.horizontal, 16)
+        .padding(.vertical, 14)
+        .background(NativeTheme.sidebar)
     }
 
     @ViewBuilder
@@ -96,5 +137,33 @@ struct WorkspaceGitHubReviewsView: View {
             return
         }
         NSWorkspace.shared.open(url)
+    }
+
+    private var reviewFilterTint: Color {
+        switch viewModel.reviewFilter.state {
+        case .open:
+            return .green
+        case .closed:
+            return .purple
+        }
+    }
+
+    private var trimmedReviewSearchText: String? {
+        let trimmed = viewModel.reviewFilter.searchText.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+
+    private func filterBadge(title: String, tint: Color) -> some View {
+        Text(title)
+            .font(.caption.weight(.semibold))
+            .foregroundStyle(tint)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(tint.opacity(0.12))
+            .overlay(
+                Capsule()
+                    .stroke(tint.opacity(0.28), lineWidth: 1)
+            )
+            .clipShape(.capsule)
     }
 }

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubRootView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubRootView.swift
@@ -3,6 +3,7 @@ import DevHavenCore
 
 struct WorkspaceGitHubRootView: View {
     @Bindable var viewModel: WorkspaceGitHubViewModel
+    let onCreateIssueWorktree: ((WorkspaceGitHubIssueDetail) throws -> Void)?
 
     var body: some View {
         VStack(spacing: 0) {
@@ -68,7 +69,10 @@ struct WorkspaceGitHubRootView: View {
             case .pulls:
                 WorkspaceGitHubPullsView(viewModel: viewModel)
             case .issues:
-                WorkspaceGitHubIssuesView(viewModel: viewModel)
+                WorkspaceGitHubIssuesView(
+                    viewModel: viewModel,
+                    onCreateIssueWorktree: onCreateIssueWorktree
+                )
             case .reviews:
                 WorkspaceGitHubReviewsView(viewModel: viewModel)
             }

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubRootView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubRootView.swift
@@ -1,0 +1,81 @@
+import SwiftUI
+import DevHavenCore
+
+struct WorkspaceGitHubRootView: View {
+    @Bindable var viewModel: WorkspaceGitHubViewModel
+
+    var body: some View {
+        VStack(spacing: 0) {
+            WorkspaceGitHubToolbarView(viewModel: viewModel)
+                .padding(.horizontal, 18)
+                .padding(.vertical, 14)
+                .background(NativeTheme.surface)
+                .overlay(alignment: .bottom) {
+                    Rectangle()
+                        .fill(NativeTheme.border)
+                        .frame(height: 1)
+                }
+
+            if let errorMessage = viewModel.errorMessage {
+                Text(errorMessage)
+                    .font(.callout)
+                    .foregroundStyle(NativeTheme.warning)
+                    .padding(.horizontal, 18)
+                    .padding(.vertical, 12)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .background(NativeTheme.warning.opacity(0.12))
+            }
+
+            content
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+        }
+        .background(NativeTheme.window)
+        .onAppear {
+            viewModel.refreshIfNeeded()
+        }
+        .onChange(of: viewModel.repositoryContext) { _, _ in
+            viewModel.refresh()
+        }
+    }
+
+    @ViewBuilder
+    private var content: some View {
+        if viewModel.isLoading, !hasAnyLoadedItems {
+            ProgressView("正在加载 GitHub 协作信息…")
+                .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if viewModel.gitHubContext == nil {
+            ContentUnavailableView(
+                viewModel.errorMessage == nil ? "未解析到远端仓库" : "GitHub 仓库上下文不可用",
+                systemImage: "link.badge.plus",
+                description: Text(
+                    viewModel.errorMessage == nil
+                        ? "请确认当前项目配置了可解析的 GitHub 远端。"
+                        : "请先处理上方错误信息，然后重新刷新。"
+                )
+            )
+            .foregroundStyle(NativeTheme.textSecondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else if !viewModel.authStatus.isAuthenticated {
+            ContentUnavailableView(
+                "GitHub 未登录",
+                systemImage: "person.crop.circle.badge.exclamationmark",
+                description: Text(viewModel.authStatus.summaryText)
+            )
+            .foregroundStyle(NativeTheme.textSecondary)
+            .frame(maxWidth: .infinity, maxHeight: .infinity)
+        } else {
+            switch viewModel.section {
+            case .pulls:
+                WorkspaceGitHubPullsView(viewModel: viewModel)
+            case .issues:
+                WorkspaceGitHubIssuesView(viewModel: viewModel)
+            case .reviews:
+                WorkspaceGitHubReviewsView(viewModel: viewModel)
+            }
+        }
+    }
+
+    private var hasAnyLoadedItems: Bool {
+        !viewModel.pulls.isEmpty || !viewModel.issues.isEmpty || !viewModel.reviewRequests.isEmpty
+    }
+}

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubRowViews.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubRowViews.swift
@@ -15,6 +15,18 @@ func gitHubAbsoluteDateText(_ date: Date) -> String {
     return formatter.string(from: date)
 }
 
+func gitHubActorSummaryText(_ actor: WorkspaceGitHubActor?) -> String? {
+    guard let actor else {
+        return nil
+    }
+    if let login = actor.login?.trimmingCharacters(in: .whitespacesAndNewlines),
+       !login.isEmpty {
+        return "@\(login)"
+    }
+    let displayName = actor.displayName.trimmingCharacters(in: .whitespacesAndNewlines)
+    return displayName.isEmpty ? nil : displayName
+}
+
 func gitHubLabelColor(_ hex: String) -> Color {
     let sanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "#", with: "")
     guard sanitized.count == 6, let value = Int(sanitized, radix: 16) else {
@@ -193,6 +205,22 @@ func gitHubPullStateColor(_ state: WorkspaceGitHubPullState, isDraft: Bool) -> C
     }
 }
 
+func gitHubPullStateSymbolName(_ state: WorkspaceGitHubPullState, isDraft: Bool) -> String {
+    if isDraft {
+        return "pencil.circle.fill"
+    }
+    switch state {
+    case .open:
+        return "arrow.triangle.pull"
+    case .closed:
+        return "xmark.circle.fill"
+    case .merged:
+        return "arrow.triangle.branch"
+    case .unknown:
+        return "circle.fill"
+    }
+}
+
 func gitHubIssueStateColor(_ state: WorkspaceGitHubIssueState) -> Color {
     switch state {
     case .open:
@@ -201,6 +229,17 @@ func gitHubIssueStateColor(_ state: WorkspaceGitHubIssueState) -> Color {
         return .purple
     case .unknown:
         return NativeTheme.textSecondary
+    }
+}
+
+func gitHubIssueStateSymbolName(_ state: WorkspaceGitHubIssueState) -> String {
+    switch state {
+    case .open:
+        return "exclamationmark.circle.fill"
+    case .closed:
+        return "checkmark.circle.fill"
+    case .unknown:
+        return "circle.fill"
     }
 }
 
@@ -264,58 +303,79 @@ struct WorkspaceGitHubPullRowView: View {
 
     var body: some View {
         Button(action: onSelect) {
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(alignment: .top, spacing: 8) {
-                    Circle()
-                        .fill(gitHubPullStateColor(pull.state, isDraft: pull.isDraft))
-                        .frame(width: 9, height: 9)
-                        .padding(.top, 5)
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: gitHubPullStateSymbolName(pull.state, isDraft: pull.isDraft))
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(gitHubPullStateColor(pull.state, isDraft: pull.isDraft))
+                    .padding(.top, 2)
 
-                    VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
                         Text(pull.title)
                             .font(.callout.weight(.semibold))
                             .foregroundStyle(NativeTheme.textPrimary)
                             .lineLimit(2)
 
-                        Text("#\(pull.number) · \(pull.headRefName) -> \(pull.baseRefName)")
+                        Text("#\(pull.number)")
                             .font(.caption)
                             .foregroundStyle(NativeTheme.textSecondary)
                             .lineLimit(1)
                     }
-                    Spacer(minLength: 0)
-                }
 
-                HStack(spacing: 8) {
-                    if let author = pull.author {
-                        Text(author.login ?? author.displayName)
-                            .font(.caption)
-                            .foregroundStyle(NativeTheme.textSecondary)
-                    }
-                    Text(gitHubPullStateTitle(pull.state, isDraft: pull.isDraft))
+                    Text("\(pull.headRefName) -> \(pull.baseRefName)")
                         .font(.caption)
                         .foregroundStyle(NativeTheme.textSecondary)
-                    Text(gitHubRelativeDateText(pull.updatedAt))
-                        .font(.caption)
-                        .foregroundStyle(NativeTheme.textSecondary)
-                    Spacer(minLength: 0)
-                    if pull.commentsCount > 0 {
-                        Text("\(pull.commentsCount) 评论")
+                        .lineLimit(1)
+
+                    WorkspaceGitHubLabelStripView(labels: pull.labels, limit: 4)
+
+                    HStack(spacing: 8) {
+                        if let authorText = gitHubActorSummaryText(pull.author) {
+                            Text(authorText)
+                                .font(.caption)
+                                .foregroundStyle(NativeTheme.textSecondary)
+                        }
+
+                        Text(gitHubPullStateTitle(pull.state, isDraft: pull.isDraft))
                             .font(.caption)
                             .foregroundStyle(NativeTheme.textSecondary)
+
+                        Text("updated \(gitHubRelativeDateText(pull.updatedAt))")
+                            .font(.caption)
+                            .foregroundStyle(NativeTheme.textSecondary)
+
+                        if pull.commentsCount > 0 {
+                            HStack(spacing: 4) {
+                                Image(systemName: "text.bubble")
+                                    .font(.system(size: 11, weight: .medium))
+                                Text("\(pull.commentsCount)")
+                                    .font(.caption)
+                            }
+                            .foregroundStyle(NativeTheme.textSecondary)
+                        }
+
+                        Spacer(minLength: 0)
                     }
                 }
 
-                WorkspaceGitHubLabelStripView(labels: pull.labels)
+                Spacer(minLength: 0)
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(isSelected ? NativeTheme.accent.opacity(0.14) : NativeTheme.surface)
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(isSelected ? NativeTheme.accent.opacity(0.75) : NativeTheme.border, lineWidth: 1)
-            )
-            .clipShape(.rect(cornerRadius: 10))
+            .background(isSelected ? NativeTheme.accent.opacity(0.08) : NativeTheme.surface)
+            .overlay(alignment: .leading) {
+                if isSelected {
+                    Rectangle()
+                        .fill(NativeTheme.accent)
+                        .frame(width: 3)
+                }
+            }
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(NativeTheme.border)
+                    .frame(height: 1)
+            }
         }
         .buttonStyle(.plain)
     }
@@ -328,14 +388,14 @@ struct WorkspaceGitHubIssueRowView: View {
 
     var body: some View {
         Button(action: onSelect) {
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(alignment: .top, spacing: 8) {
-                    Circle()
-                        .fill(gitHubIssueStateColor(issue.state))
-                        .frame(width: 9, height: 9)
-                        .padding(.top, 5)
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: gitHubIssueStateSymbolName(issue.state))
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(gitHubIssueStateColor(issue.state))
+                    .padding(.top, 2)
 
-                    VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
                         Text(issue.title)
                             .font(.callout.weight(.semibold))
                             .foregroundStyle(NativeTheme.textPrimary)
@@ -344,41 +404,58 @@ struct WorkspaceGitHubIssueRowView: View {
                         Text("#\(issue.number)")
                             .font(.caption)
                             .foregroundStyle(NativeTheme.textSecondary)
+                            .lineLimit(1)
                     }
-                    Spacer(minLength: 0)
-                }
 
-                HStack(spacing: 8) {
-                    if let author = issue.author {
-                        Text(author.login ?? author.displayName)
+                    WorkspaceGitHubLabelStripView(labels: issue.labels, limit: 4)
+
+                    HStack(spacing: 8) {
+                        if let authorText = gitHubActorSummaryText(issue.author) {
+                            Text(authorText)
+                                .font(.caption)
+                                .foregroundStyle(NativeTheme.textSecondary)
+                        }
+
+                        Text(gitHubIssueStateTitle(issue.state, reason: issue.stateReason))
                             .font(.caption)
                             .foregroundStyle(NativeTheme.textSecondary)
-                    }
-                    Text(gitHubIssueStateTitle(issue.state, reason: issue.stateReason))
-                        .font(.caption)
-                        .foregroundStyle(NativeTheme.textSecondary)
-                    Text(gitHubRelativeDateText(issue.updatedAt))
-                        .font(.caption)
-                        .foregroundStyle(NativeTheme.textSecondary)
-                    Spacer(minLength: 0)
-                    if issue.commentsCount > 0 {
-                        Text("\(issue.commentsCount) 评论")
+
+                        Text("updated \(gitHubRelativeDateText(issue.updatedAt))")
                             .font(.caption)
                             .foregroundStyle(NativeTheme.textSecondary)
+
+                        if issue.commentsCount > 0 {
+                            HStack(spacing: 4) {
+                                Image(systemName: "text.bubble")
+                                    .font(.system(size: 11, weight: .medium))
+                                Text("\(issue.commentsCount)")
+                                    .font(.caption)
+                            }
+                            .foregroundStyle(NativeTheme.textSecondary)
+                        }
+
+                        Spacer(minLength: 0)
                     }
                 }
 
-                WorkspaceGitHubLabelStripView(labels: issue.labels)
+                Spacer(minLength: 0)
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(isSelected ? NativeTheme.accent.opacity(0.14) : NativeTheme.surface)
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(isSelected ? NativeTheme.accent.opacity(0.75) : NativeTheme.border, lineWidth: 1)
-            )
-            .clipShape(.rect(cornerRadius: 10))
+            .background(isSelected ? NativeTheme.accent.opacity(0.08) : NativeTheme.surface)
+            .overlay(alignment: .leading) {
+                if isSelected {
+                    Rectangle()
+                        .fill(NativeTheme.accent)
+                        .frame(width: 3)
+                }
+            }
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(NativeTheme.border)
+                    .frame(height: 1)
+            }
         }
         .buttonStyle(.plain)
     }
@@ -391,14 +468,14 @@ struct WorkspaceGitHubReviewRowView: View {
 
     var body: some View {
         Button(action: onSelect) {
-            VStack(alignment: .leading, spacing: 8) {
-                HStack(alignment: .top, spacing: 8) {
-                    Circle()
-                        .fill(gitHubPullStateColor(review.state, isDraft: review.isDraft))
-                        .frame(width: 9, height: 9)
-                        .padding(.top, 5)
+            HStack(alignment: .top, spacing: 10) {
+                Image(systemName: gitHubPullStateSymbolName(review.state, isDraft: review.isDraft))
+                    .font(.system(size: 14, weight: .semibold))
+                    .foregroundStyle(gitHubPullStateColor(review.state, isDraft: review.isDraft))
+                    .padding(.top, 2)
 
-                    VStack(alignment: .leading, spacing: 4) {
+                VStack(alignment: .leading, spacing: 8) {
+                    HStack(alignment: .firstTextBaseline, spacing: 8) {
                         Text(review.title)
                             .font(.callout.weight(.semibold))
                             .foregroundStyle(NativeTheme.textPrimary)
@@ -407,41 +484,58 @@ struct WorkspaceGitHubReviewRowView: View {
                         Text("#\(review.number)")
                             .font(.caption)
                             .foregroundStyle(NativeTheme.textSecondary)
+                            .lineLimit(1)
                     }
-                    Spacer(minLength: 0)
-                }
 
-                HStack(spacing: 8) {
-                    if let author = review.author {
-                        Text(author.login ?? author.displayName)
+                    WorkspaceGitHubLabelStripView(labels: review.labels, limit: 4)
+
+                    HStack(spacing: 8) {
+                        if let authorText = gitHubActorSummaryText(review.author) {
+                            Text(authorText)
+                                .font(.caption)
+                                .foregroundStyle(NativeTheme.textSecondary)
+                        }
+
+                        Text("Review requested")
                             .font(.caption)
                             .foregroundStyle(NativeTheme.textSecondary)
-                    }
-                    Text(gitHubPullStateTitle(review.state, isDraft: review.isDraft))
-                        .font(.caption)
-                        .foregroundStyle(NativeTheme.textSecondary)
-                    Text(gitHubRelativeDateText(review.updatedAt))
-                        .font(.caption)
-                        .foregroundStyle(NativeTheme.textSecondary)
-                    Spacer(minLength: 0)
-                    if review.commentsCount > 0 {
-                        Text("\(review.commentsCount) 评论")
+
+                        Text("updated \(gitHubRelativeDateText(review.updatedAt))")
                             .font(.caption)
                             .foregroundStyle(NativeTheme.textSecondary)
+
+                        if review.commentsCount > 0 {
+                            HStack(spacing: 4) {
+                                Image(systemName: "text.bubble")
+                                    .font(.system(size: 11, weight: .medium))
+                                Text("\(review.commentsCount)")
+                                    .font(.caption)
+                            }
+                            .foregroundStyle(NativeTheme.textSecondary)
+                        }
+
+                        Spacer(minLength: 0)
                     }
                 }
 
-                WorkspaceGitHubLabelStripView(labels: review.labels)
+                Spacer(minLength: 0)
             }
-            .padding(.horizontal, 12)
-            .padding(.vertical, 10)
+            .padding(.horizontal, 14)
+            .padding(.vertical, 12)
             .frame(maxWidth: .infinity, alignment: .leading)
-            .background(isSelected ? NativeTheme.accent.opacity(0.14) : NativeTheme.surface)
-            .overlay(
-                RoundedRectangle(cornerRadius: 10)
-                    .stroke(isSelected ? NativeTheme.accent.opacity(0.75) : NativeTheme.border, lineWidth: 1)
-            )
-            .clipShape(.rect(cornerRadius: 10))
+            .background(isSelected ? NativeTheme.accent.opacity(0.08) : NativeTheme.surface)
+            .overlay(alignment: .leading) {
+                if isSelected {
+                    Rectangle()
+                        .fill(NativeTheme.accent)
+                        .frame(width: 3)
+                }
+            }
+            .overlay(alignment: .bottom) {
+                Rectangle()
+                    .fill(NativeTheme.border)
+                    .frame(height: 1)
+            }
         }
         .buttonStyle(.plain)
     }

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubRowViews.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubRowViews.swift
@@ -1,0 +1,383 @@
+import Foundation
+import SwiftUI
+import DevHavenCore
+
+func gitHubRelativeDateText(_ date: Date) -> String {
+    let formatter = RelativeDateTimeFormatter()
+    formatter.unitsStyle = .short
+    return formatter.localizedString(for: date, relativeTo: Date())
+}
+
+func gitHubAbsoluteDateText(_ date: Date) -> String {
+    let formatter = DateFormatter()
+    formatter.dateStyle = .medium
+    formatter.timeStyle = .short
+    return formatter.string(from: date)
+}
+
+func gitHubLabelColor(_ hex: String) -> Color {
+    let sanitized = hex.trimmingCharacters(in: .whitespacesAndNewlines).replacingOccurrences(of: "#", with: "")
+    guard sanitized.count == 6, let value = Int(sanitized, radix: 16) else {
+        return NativeTheme.accent
+    }
+    let red = Double((value >> 16) & 0xFF) / 255
+    let green = Double((value >> 8) & 0xFF) / 255
+    let blue = Double(value & 0xFF) / 255
+    return Color(red: red, green: green, blue: blue)
+}
+
+func gitHubPullStateTitle(_ state: WorkspaceGitHubPullState, isDraft: Bool) -> String {
+    if isDraft {
+        return "Draft"
+    }
+    switch state {
+    case .open:
+        return "Open"
+    case .closed:
+        return "Closed"
+    case .merged:
+        return "Merged"
+    case let .unknown(value):
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Unknown" : trimmed
+    }
+}
+
+func gitHubIssueStateReasonTitle(_ reason: WorkspaceGitHubIssueStateReason) -> String {
+    switch reason {
+    case .completed:
+        return "Completed"
+    case .notPlanned:
+        return "Not planned"
+    case .reopened:
+        return "Reopened"
+    case .none:
+        return "None"
+    case let .unknown(value):
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Unknown" : trimmed
+    }
+}
+
+func gitHubIssueStateTitle(
+    _ state: WorkspaceGitHubIssueState,
+    reason: WorkspaceGitHubIssueStateReason = .none
+) -> String {
+    switch state {
+    case .open:
+        return "Open"
+    case .closed:
+        return reason == .none ? "Closed" : "Closed · \(gitHubIssueStateReasonTitle(reason))"
+    case let .unknown(value):
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Unknown" : trimmed
+    }
+}
+
+func gitHubReviewDecisionTitle(_ decision: WorkspaceGitHubReviewDecision) -> String {
+    switch decision {
+    case .none:
+        return "None"
+    case .approved:
+        return "Approved"
+    case .changesRequested:
+        return "Changes requested"
+    case .reviewRequired:
+        return "Review required"
+    case let .unknown(value):
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Unknown" : trimmed
+    }
+}
+
+func gitHubMergeStateTitle(_ status: WorkspaceGitHubMergeStateStatus) -> String {
+    switch status {
+    case .clean:
+        return "Clean"
+    case .blocked:
+        return "Blocked"
+    case .behind:
+        return "Behind"
+    case .dirty:
+        return "Dirty"
+    case .draft:
+        return "Draft"
+    case .hasHooks:
+        return "Has hooks"
+    case .unstable:
+        return "Unstable"
+    case let .unknown(value):
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? "Unknown" : trimmed
+    }
+}
+
+func gitHubPullStateColor(_ state: WorkspaceGitHubPullState, isDraft: Bool) -> Color {
+    if isDraft {
+        return NativeTheme.textSecondary
+    }
+    switch state {
+    case .open:
+        return .green
+    case .closed:
+        return .red
+    case .merged:
+        return .purple
+    case .unknown:
+        return NativeTheme.textSecondary
+    }
+}
+
+func gitHubIssueStateColor(_ state: WorkspaceGitHubIssueState) -> Color {
+    switch state {
+    case .open:
+        return .green
+    case .closed:
+        return .purple
+    case .unknown:
+        return NativeTheme.textSecondary
+    }
+}
+
+private struct WorkspaceGitHubLabelStripView: View {
+    let labels: [WorkspaceGitHubLabel]
+    var limit: Int = 3
+
+    var body: some View {
+        if !labels.isEmpty {
+            ScrollView(.horizontal, showsIndicators: false) {
+                HStack(spacing: 6) {
+                    ForEach(Array(labels.prefix(limit))) { label in
+                        Text(label.name)
+                            .font(.caption2.weight(.semibold))
+                            .padding(.horizontal, 6)
+                            .padding(.vertical, 3)
+                            .background(gitHubLabelColor(label.color ?? "").opacity(0.18))
+                            .foregroundStyle(NativeTheme.textPrimary)
+                            .clipShape(.capsule)
+                    }
+                }
+            }
+        }
+    }
+}
+
+struct WorkspaceGitHubListLoadingOverlay: View {
+    let title: String
+
+    var body: some View {
+        VStack {
+            HStack(spacing: 8) {
+                ProgressView()
+                    .controlSize(.small)
+                Text(title)
+                    .font(.caption.weight(.semibold))
+                    .foregroundStyle(NativeTheme.textPrimary)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 8)
+            .background(.regularMaterial)
+            .clipShape(.capsule)
+            .overlay(
+                Capsule()
+                    .stroke(NativeTheme.border, lineWidth: 1)
+            )
+
+            Spacer(minLength: 0)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .top)
+        .background(NativeTheme.window.opacity(0.12))
+        .allowsHitTesting(false)
+    }
+}
+
+struct WorkspaceGitHubPullRowView: View {
+    let pull: WorkspaceGitHubPullSummary
+    let isSelected: Bool
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .top, spacing: 8) {
+                    Circle()
+                        .fill(gitHubPullStateColor(pull.state, isDraft: pull.isDraft))
+                        .frame(width: 9, height: 9)
+                        .padding(.top, 5)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(pull.title)
+                            .font(.callout.weight(.semibold))
+                            .foregroundStyle(NativeTheme.textPrimary)
+                            .lineLimit(2)
+
+                        Text("#\(pull.number) · \(pull.headRefName) -> \(pull.baseRefName)")
+                            .font(.caption)
+                            .foregroundStyle(NativeTheme.textSecondary)
+                            .lineLimit(1)
+                    }
+                    Spacer(minLength: 0)
+                }
+
+                HStack(spacing: 8) {
+                    if let author = pull.author {
+                        Text(author.login ?? author.displayName)
+                            .font(.caption)
+                            .foregroundStyle(NativeTheme.textSecondary)
+                    }
+                    Text(gitHubPullStateTitle(pull.state, isDraft: pull.isDraft))
+                        .font(.caption)
+                        .foregroundStyle(NativeTheme.textSecondary)
+                    Text(gitHubRelativeDateText(pull.updatedAt))
+                        .font(.caption)
+                        .foregroundStyle(NativeTheme.textSecondary)
+                    Spacer(minLength: 0)
+                    if pull.commentsCount > 0 {
+                        Text("\(pull.commentsCount) 评论")
+                            .font(.caption)
+                            .foregroundStyle(NativeTheme.textSecondary)
+                    }
+                }
+
+                WorkspaceGitHubLabelStripView(labels: pull.labels)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(isSelected ? NativeTheme.accent.opacity(0.14) : NativeTheme.surface)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(isSelected ? NativeTheme.accent.opacity(0.75) : NativeTheme.border, lineWidth: 1)
+            )
+            .clipShape(.rect(cornerRadius: 10))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+struct WorkspaceGitHubIssueRowView: View {
+    let issue: WorkspaceGitHubIssueSummary
+    let isSelected: Bool
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .top, spacing: 8) {
+                    Circle()
+                        .fill(gitHubIssueStateColor(issue.state))
+                        .frame(width: 9, height: 9)
+                        .padding(.top, 5)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(issue.title)
+                            .font(.callout.weight(.semibold))
+                            .foregroundStyle(NativeTheme.textPrimary)
+                            .lineLimit(2)
+
+                        Text("#\(issue.number)")
+                            .font(.caption)
+                            .foregroundStyle(NativeTheme.textSecondary)
+                    }
+                    Spacer(minLength: 0)
+                }
+
+                HStack(spacing: 8) {
+                    if let author = issue.author {
+                        Text(author.login ?? author.displayName)
+                            .font(.caption)
+                            .foregroundStyle(NativeTheme.textSecondary)
+                    }
+                    Text(gitHubIssueStateTitle(issue.state, reason: issue.stateReason))
+                        .font(.caption)
+                        .foregroundStyle(NativeTheme.textSecondary)
+                    Text(gitHubRelativeDateText(issue.updatedAt))
+                        .font(.caption)
+                        .foregroundStyle(NativeTheme.textSecondary)
+                    Spacer(minLength: 0)
+                    if issue.commentsCount > 0 {
+                        Text("\(issue.commentsCount) 评论")
+                            .font(.caption)
+                            .foregroundStyle(NativeTheme.textSecondary)
+                    }
+                }
+
+                WorkspaceGitHubLabelStripView(labels: issue.labels)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(isSelected ? NativeTheme.accent.opacity(0.14) : NativeTheme.surface)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(isSelected ? NativeTheme.accent.opacity(0.75) : NativeTheme.border, lineWidth: 1)
+            )
+            .clipShape(.rect(cornerRadius: 10))
+        }
+        .buttonStyle(.plain)
+    }
+}
+
+struct WorkspaceGitHubReviewRowView: View {
+    let review: WorkspaceGitHubReviewRequestSummary
+    let isSelected: Bool
+    let onSelect: () -> Void
+
+    var body: some View {
+        Button(action: onSelect) {
+            VStack(alignment: .leading, spacing: 8) {
+                HStack(alignment: .top, spacing: 8) {
+                    Circle()
+                        .fill(gitHubPullStateColor(review.state, isDraft: review.isDraft))
+                        .frame(width: 9, height: 9)
+                        .padding(.top, 5)
+
+                    VStack(alignment: .leading, spacing: 4) {
+                        Text(review.title)
+                            .font(.callout.weight(.semibold))
+                            .foregroundStyle(NativeTheme.textPrimary)
+                            .lineLimit(2)
+
+                        Text("#\(review.number)")
+                            .font(.caption)
+                            .foregroundStyle(NativeTheme.textSecondary)
+                    }
+                    Spacer(minLength: 0)
+                }
+
+                HStack(spacing: 8) {
+                    if let author = review.author {
+                        Text(author.login ?? author.displayName)
+                            .font(.caption)
+                            .foregroundStyle(NativeTheme.textSecondary)
+                    }
+                    Text(gitHubPullStateTitle(review.state, isDraft: review.isDraft))
+                        .font(.caption)
+                        .foregroundStyle(NativeTheme.textSecondary)
+                    Text(gitHubRelativeDateText(review.updatedAt))
+                        .font(.caption)
+                        .foregroundStyle(NativeTheme.textSecondary)
+                    Spacer(minLength: 0)
+                    if review.commentsCount > 0 {
+                        Text("\(review.commentsCount) 评论")
+                            .font(.caption)
+                            .foregroundStyle(NativeTheme.textSecondary)
+                    }
+                }
+
+                WorkspaceGitHubLabelStripView(labels: review.labels)
+            }
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .background(isSelected ? NativeTheme.accent.opacity(0.14) : NativeTheme.surface)
+            .overlay(
+                RoundedRectangle(cornerRadius: 10)
+                    .stroke(isSelected ? NativeTheme.accent.opacity(0.75) : NativeTheme.border, lineWidth: 1)
+            )
+            .clipShape(.rect(cornerRadius: 10))
+        }
+        .buttonStyle(.plain)
+    }
+}

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubRowViews.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubRowViews.swift
@@ -112,6 +112,71 @@ func gitHubMergeStateTitle(_ status: WorkspaceGitHubMergeStateStatus) -> String 
     }
 }
 
+func gitHubReviewSubmissionTitle(_ event: WorkspaceGitHubReviewSubmissionEvent) -> String {
+    switch event {
+    case .comment:
+        return "评论"
+    case .approve:
+        return "通过"
+    case .requestChanges:
+        return "请求修改"
+    }
+}
+
+func gitHubMutationStatusText(_ kind: WorkspaceGitHubMutationKind) -> String {
+    switch kind {
+    case .addIssueComment:
+        return "正在提交 Issue 评论…"
+    case .closeIssue:
+        return "正在关闭 Issue…"
+    case .reopenIssue:
+        return "正在重新打开 Issue…"
+    case .createIssueBranch:
+        return "正在创建并切换 Issue 分支…"
+    case .createIssueWorktree:
+        return "已开始创建 Issue worktree…"
+    case .addPullComment:
+        return "正在提交 PR 评论…"
+    case .closePull:
+        return "正在关闭 Pull Request…"
+    case .reopenPull:
+        return "正在重新打开 Pull Request…"
+    case let .mergePull(method):
+        return "正在执行 \(method.title) …"
+    case .checkoutPullBranch:
+        return "正在 checkout PR 分支…"
+    case let .submitReview(event):
+        return "正在提交 Review\(gitHubReviewSubmissionTitle(event))…"
+    }
+}
+
+func gitHubMutationSuccessText(_ kind: WorkspaceGitHubMutationKind) -> String {
+    switch kind {
+    case .addIssueComment:
+        return "Issue 评论已提交"
+    case .closeIssue:
+        return "Issue 已关闭"
+    case .reopenIssue:
+        return "Issue 已重新打开"
+    case .createIssueBranch:
+        return "Issue 分支已创建并切换"
+    case .createIssueWorktree:
+        return "已开始创建并打开 Issue worktree"
+    case .addPullComment:
+        return "PR 评论已提交"
+    case .closePull:
+        return "Pull Request 已关闭"
+    case .reopenPull:
+        return "Pull Request 已重新打开"
+    case let .mergePull(method):
+        return "\(method.title) 已提交"
+    case .checkoutPullBranch:
+        return "PR 分支已 checkout"
+    case let .submitReview(event):
+        return "Review\(gitHubReviewSubmissionTitle(event))已提交"
+    }
+}
+
 func gitHubPullStateColor(_ state: WorkspaceGitHubPullState, isDraft: Bool) -> Color {
     if isDraft {
         return NativeTheme.textSecondary

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubToolbarView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubToolbarView.swift
@@ -37,6 +37,24 @@ struct WorkspaceGitHubToolbarView: View {
                     )
                 }
 
+                if viewModel.isMutating {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text(viewModel.activeMutation.map(gitHubMutationStatusText) ?? "正在执行 GitHub 操作…")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(NativeTheme.textPrimary)
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(NativeTheme.elevated)
+                    .clipShape(.capsule)
+                    .overlay(
+                        Capsule()
+                            .stroke(NativeTheme.border, lineWidth: 1)
+                    )
+                }
+
                 Button("刷新") {
                     viewModel.refresh()
                 }

--- a/macos/Sources/DevHavenApp/WorkspaceGitHubToolbarView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceGitHubToolbarView.swift
@@ -1,0 +1,245 @@
+import SwiftUI
+import DevHavenCore
+
+struct WorkspaceGitHubToolbarView: View {
+    @Bindable var viewModel: WorkspaceGitHubViewModel
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            HStack(alignment: .center, spacing: 12) {
+                Picker("Section", selection: sectionBinding) {
+                    ForEach(WorkspaceGitHubSection.allCases) { section in
+                        Text(section.title).tag(section)
+                    }
+                }
+                .pickerStyle(.segmented)
+                .frame(maxWidth: 360)
+
+                sectionStatePicker
+
+                Spacer(minLength: 0)
+
+                if viewModel.isLoading {
+                    HStack(spacing: 8) {
+                        ProgressView()
+                            .controlSize(.small)
+                        Text("刷新中…")
+                            .font(.caption.weight(.semibold))
+                            .foregroundStyle(NativeTheme.textPrimary)
+                    }
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 6)
+                    .background(NativeTheme.elevated)
+                    .clipShape(.capsule)
+                    .overlay(
+                        Capsule()
+                            .stroke(NativeTheme.border, lineWidth: 1)
+                    )
+                }
+
+                Button("刷新") {
+                    viewModel.refresh()
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(NativeTheme.accent)
+            }
+
+            HStack(spacing: 12) {
+                TextField(searchPrompt, text: searchBinding)
+                    .textFieldStyle(.roundedBorder)
+                    .onSubmit {
+                        viewModel.refresh()
+                    }
+
+                statusBadge
+            }
+
+            Text(viewModel.displayRepositoryTitle)
+                .font(.caption2.monospaced())
+                .foregroundStyle(NativeTheme.textSecondary)
+                .lineLimit(1)
+                .textSelection(.enabled)
+        }
+    }
+
+    @ViewBuilder
+    private var sectionStatePicker: some View {
+        switch viewModel.section {
+        case .pulls:
+            Picker("状态", selection: pullStateBinding) {
+                ForEach(WorkspaceGitHubPullFilterState.allCases) { state in
+                    Text(state.title).tag(state)
+                }
+            }
+            .pickerStyle(.menu)
+            .frame(width: 120)
+        case .issues:
+            Picker("状态", selection: issueStateBinding) {
+                ForEach(WorkspaceGitHubIssueFilterState.allCases) { state in
+                    Text(state.title).tag(state)
+                }
+            }
+            .pickerStyle(.menu)
+            .frame(width: 120)
+        case .reviews:
+            HStack(spacing: 8) {
+                Picker("状态", selection: reviewStateBinding) {
+                    ForEach(WorkspaceGitHubReviewFilterState.allCases) { state in
+                        Text(state.title).tag(state)
+                    }
+                }
+                .pickerStyle(.menu)
+                .frame(width: 120)
+
+                Picker("范围", selection: reviewScopeBinding) {
+                    ForEach(WorkspaceGitHubReviewScope.allCases) { scope in
+                        Text(scope.title).tag(scope)
+                    }
+                }
+                .pickerStyle(.menu)
+                .frame(width: 140)
+            }
+        }
+    }
+
+    private var searchBinding: Binding<String> {
+        switch viewModel.section {
+        case .pulls:
+            Binding(
+                get: { viewModel.pullFilter.searchText },
+                set: { newValue in
+                    var filter = viewModel.pullFilter
+                    filter.searchText = newValue
+                    viewModel.pullFilter = filter
+                }
+            )
+        case .issues:
+            Binding(
+                get: { viewModel.issueFilter.searchText },
+                set: { newValue in
+                    var filter = viewModel.issueFilter
+                    filter.searchText = newValue
+                    viewModel.issueFilter = filter
+                }
+            )
+        case .reviews:
+            Binding(
+                get: { viewModel.reviewFilter.searchText },
+                set: { newValue in
+                    var filter = viewModel.reviewFilter
+                    filter.searchText = newValue
+                    viewModel.reviewFilter = filter
+                }
+            )
+        }
+    }
+
+    private var pullStateBinding: Binding<WorkspaceGitHubPullFilterState> {
+        Binding(
+            get: { viewModel.pullFilter.state },
+            set: { newValue in
+                guard viewModel.pullFilter.state != newValue else {
+                    return
+                }
+                var filter = viewModel.pullFilter
+                filter.state = newValue
+                viewModel.pullFilter = filter
+                viewModel.refresh()
+            }
+        )
+    }
+
+    private var issueStateBinding: Binding<WorkspaceGitHubIssueFilterState> {
+        Binding(
+            get: { viewModel.issueFilter.state },
+            set: { newValue in
+                guard viewModel.issueFilter.state != newValue else {
+                    return
+                }
+                var filter = viewModel.issueFilter
+                filter.state = newValue
+                viewModel.issueFilter = filter
+                viewModel.refresh()
+            }
+        )
+    }
+
+    private var reviewStateBinding: Binding<WorkspaceGitHubReviewFilterState> {
+        Binding(
+            get: { viewModel.reviewFilter.state },
+            set: { newValue in
+                guard viewModel.reviewFilter.state != newValue else {
+                    return
+                }
+                var filter = viewModel.reviewFilter
+                filter.state = newValue
+                viewModel.reviewFilter = filter
+                viewModel.refresh()
+            }
+        )
+    }
+
+    private var reviewScopeBinding: Binding<WorkspaceGitHubReviewScope> {
+        Binding(
+            get: { viewModel.reviewFilter.scope },
+            set: { newValue in
+                guard viewModel.reviewFilter.scope != newValue else {
+                    return
+                }
+                var filter = viewModel.reviewFilter
+                filter.scope = newValue
+                viewModel.reviewFilter = filter
+                viewModel.refresh()
+            }
+        )
+    }
+
+    private var searchPrompt: String {
+        switch viewModel.section {
+        case .pulls:
+            return "按标题 / 作者 / 分支搜索 PR"
+        case .issues:
+            return "按标题 / 作者 / 标签搜索 Issue"
+        case .reviews:
+            return "按标题 / 作者 / 标签搜索 Review"
+        }
+    }
+
+    private var sectionBinding: Binding<WorkspaceGitHubSection> {
+        Binding(
+            get: { viewModel.section },
+            set: { viewModel.setSection($0) }
+        )
+    }
+
+    private var statusBadge: some View {
+        HStack(spacing: 6) {
+            Circle()
+                .fill(authBadgeColor)
+                .frame(width: 8, height: 8)
+            Text(viewModel.authStatus.activeLogin ?? (viewModel.authStatus.isAuthenticated ? "已登录" : "未登录"))
+                .font(.caption.weight(.semibold))
+                .foregroundStyle(NativeTheme.textPrimary)
+        }
+        .padding(.horizontal, 10)
+        .padding(.vertical, 6)
+        .background(NativeTheme.elevated)
+        .overlay(
+            Capsule()
+                .stroke(NativeTheme.border, lineWidth: 1)
+        )
+        .clipShape(.capsule)
+        .help(viewModel.authStatus.summaryText)
+    }
+
+    private var authBadgeColor: Color {
+        switch viewModel.authStatus.state {
+        case .unknown:
+            return NativeTheme.textSecondary
+        case .authenticated:
+            return .green
+        case .unauthenticated:
+            return .orange
+        }
+    }
+}

--- a/macos/Sources/DevHavenApp/WorkspaceShellView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceShellView.swift
@@ -153,7 +153,10 @@ struct WorkspaceShellView: View {
                 description: "请切换到一个真实项目工作区后再查看 GitHub 协作信息。"
             )
         } else if let gitHubViewModel = viewModel.activeWorkspaceGitHubViewModel {
-            WorkspaceGitHubRootView(viewModel: gitHubViewModel)
+            WorkspaceGitHubRootView(
+                viewModel: gitHubViewModel,
+                onCreateIssueWorktree: createIssueWorktree
+            )
         } else {
             gitModeEmptyState(
                 title: "GitHub 面板尚未就绪",
@@ -321,6 +324,37 @@ struct WorkspaceShellView: View {
     private func gitLogDiffTitle(for file: WorkspaceGitCommitFileChange) -> String {
         let fileName = (file.path as NSString).lastPathComponent
         return fileName.isEmpty ? file.path : fileName
+    }
+
+    private func createIssueWorktree(from detail: WorkspaceGitHubIssueDetail) throws {
+        guard let rootProject = viewModel.activeWorkspaceRootProject else {
+            throw WorkspaceGitHubCommandError.operationRejected("当前未找到可用的 root project")
+        }
+        guard let baseBranch = activeWorkspaceBaseBranchCandidate() else {
+            throw WorkspaceGitHubCommandError.operationRejected(
+                "当前 root project 未检测到基线分支，暂时无法从 Issue 创建 worktree。"
+            )
+        }
+        try viewModel.startCreateWorkspaceWorktree(
+            from: rootProject.path,
+            branch: detail.suggestedBranchName,
+            createBranch: true,
+            baseBranch: baseBranch,
+            autoOpen: true
+        )
+    }
+
+    private func activeWorkspaceBaseBranchCandidate() -> String? {
+        guard let rootProject = viewModel.activeWorkspaceRootProject,
+              let activeProject = viewModel.activeWorkspaceProject
+        else {
+            return nil
+        }
+        if activeProject.path != rootProject.path,
+           let worktree = rootProject.worktrees.first(where: { $0.path == activeProject.path }) {
+            return worktree.branch
+        }
+        return viewModel.activeWorkspaceRootCurrentBranchName
     }
 
     private func syncTerminalStores() {

--- a/macos/Sources/DevHavenApp/WorkspaceShellView.swift
+++ b/macos/Sources/DevHavenApp/WorkspaceShellView.swift
@@ -145,6 +145,25 @@ struct WorkspaceShellView: View {
     }
 
     @ViewBuilder
+    private var gitHubToolWindowContent: some View {
+        if isActiveQuickTerminalSession {
+            gitModeEmptyState(
+                title: "快速终端暂不支持 GitHub 模式",
+                systemImage: "bolt.horizontal.circle",
+                description: "请切换到一个真实项目工作区后再查看 GitHub 协作信息。"
+            )
+        } else if let gitHubViewModel = viewModel.activeWorkspaceGitHubViewModel {
+            WorkspaceGitHubRootView(viewModel: gitHubViewModel)
+        } else {
+            gitModeEmptyState(
+                title: "GitHub 面板尚未就绪",
+                systemImage: "tray",
+                description: "请确认当前项目是 GitHub 仓库，并且本机 gh 已完成登录。"
+            )
+        }
+    }
+
+    @ViewBuilder
     private func topWorkspaceContent(totalWidth: CGFloat) -> some View {
         if viewModel.workspaceSideToolWindowState.isVisible,
            viewModel.workspaceSideToolWindowState.activeKind != nil {
@@ -165,7 +184,7 @@ struct WorkspaceShellView: View {
                         WorkspaceProjectToolWindowHostView(viewModel: viewModel)
                     case .commit:
                         WorkspaceCommitSideToolWindowHostView(viewModel: viewModel)
-                    case .git, .none:
+                    case .git, .github, .none:
                         EmptyView()
                     }
                 }
@@ -200,17 +219,25 @@ struct WorkspaceShellView: View {
                     .frame(maxWidth: .infinity, maxHeight: .infinity)
             } trailing: {
                 Group {
-                    if viewModel.workspaceBottomToolWindowState.activeKind == .git {
+                    switch viewModel.workspaceBottomToolWindowState.activeKind {
+                    case .git:
                         gitToolWindowContent
-                    } else {
+                    case .github:
+                        gitHubToolWindowContent
+                    default:
                         EmptyView()
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)
                 .contentShape(Rectangle())
                 .onTapGesture {
-                    if viewModel.workspaceBottomToolWindowState.activeKind == .git {
+                    switch viewModel.workspaceBottomToolWindowState.activeKind {
+                    case .git:
                         viewModel.setWorkspaceFocusedArea(.bottomToolWindow(.git))
+                    case .github:
+                        viewModel.setWorkspaceFocusedArea(.bottomToolWindow(.github))
+                    default:
+                        break
                     }
                 }
                 .frame(maxWidth: .infinity, maxHeight: .infinity)

--- a/macos/Sources/DevHavenCore/Models/WorkspaceGitHubFilterModels.swift
+++ b/macos/Sources/DevHavenCore/Models/WorkspaceGitHubFilterModels.swift
@@ -1,0 +1,266 @@
+import Foundation
+
+public enum WorkspaceGitHubPullFilterState: String, CaseIterable, Identifiable, Sendable {
+    case open
+    case closed
+    case merged
+    case all
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .open:
+            return "Open"
+        case .closed:
+            return "Closed"
+        case .merged:
+            return "Merged"
+        case .all:
+            return "全部"
+        }
+    }
+
+    var ghArgument: String {
+        rawValue
+    }
+}
+
+public enum WorkspaceGitHubIssueFilterState: String, CaseIterable, Identifiable, Sendable {
+    case open
+    case closed
+    case all
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .open:
+            return "Open"
+        case .closed:
+            return "Closed"
+        case .all:
+            return "全部"
+        }
+    }
+
+    var ghArgument: String {
+        rawValue
+    }
+}
+
+public enum WorkspaceGitHubReviewFilterState: String, CaseIterable, Identifiable, Sendable {
+    case open
+    case closed
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .open:
+            return "Open"
+        case .closed:
+            return "Closed"
+        }
+    }
+
+    var ghArgument: String {
+        rawValue
+    }
+}
+
+public enum WorkspaceGitHubReviewScope: String, CaseIterable, Identifiable, Sendable {
+    case requestedToMe
+    case involvingMe
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .requestedToMe:
+            return "请求我 Review"
+        case .involvingMe:
+            return "与我相关"
+        }
+    }
+}
+
+public struct WorkspaceGitHubPullFilter: Equatable, Sendable {
+    public static let defaultLimit = 50
+
+    public var limit: Int
+    public var state: WorkspaceGitHubPullFilterState
+    public var searchText: String
+    public var author: String?
+    public var assignee: String?
+    public var labels: [String]
+    public var baseBranch: String?
+    public var headBranch: String?
+    public var draftOnly: Bool
+    public var authoredByMe: Bool
+    public var assignedToMe: Bool
+
+    public init(
+        limit: Int = WorkspaceGitHubPullFilter.defaultLimit,
+        state: WorkspaceGitHubPullFilterState = .open,
+        searchText: String = "",
+        author: String? = nil,
+        assignee: String? = nil,
+        labels: [String] = [],
+        baseBranch: String? = nil,
+        headBranch: String? = nil,
+        draftOnly: Bool = false,
+        authoredByMe: Bool = false,
+        assignedToMe: Bool = false
+    ) {
+        self.limit = max(1, limit)
+        self.state = state
+        self.searchText = searchText
+        self.author = author
+        self.assignee = assignee
+        self.labels = labels
+        self.baseBranch = baseBranch
+        self.headBranch = headBranch
+        self.draftOnly = draftOnly
+        self.authoredByMe = authoredByMe
+        self.assignedToMe = assignedToMe
+    }
+
+    public var normalizedSearchText: String? {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+
+    public var normalizedAuthor: String? {
+        if authoredByMe {
+            return "@me"
+        }
+        return author?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+
+    public var normalizedAssignee: String? {
+        if assignedToMe {
+            return "@me"
+        }
+        return assignee?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+
+    public var normalizedLabels: [String] {
+        labels.compactMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty }
+    }
+
+    public var normalizedBaseBranch: String? {
+        baseBranch?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+
+    public var normalizedHeadBranch: String? {
+        headBranch?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+}
+
+public struct WorkspaceGitHubIssueFilter: Equatable, Sendable {
+    public static let defaultLimit = 50
+
+    public var limit: Int
+    public var state: WorkspaceGitHubIssueFilterState
+    public var searchText: String
+    public var author: String?
+    public var assignee: String?
+    public var labels: [String]
+    public var milestone: String?
+    public var authoredByMe: Bool
+    public var assignedToMe: Bool
+
+    public init(
+        limit: Int = WorkspaceGitHubIssueFilter.defaultLimit,
+        state: WorkspaceGitHubIssueFilterState = .open,
+        searchText: String = "",
+        author: String? = nil,
+        assignee: String? = nil,
+        labels: [String] = [],
+        milestone: String? = nil,
+        authoredByMe: Bool = false,
+        assignedToMe: Bool = false
+    ) {
+        self.limit = max(1, limit)
+        self.state = state
+        self.searchText = searchText
+        self.author = author
+        self.assignee = assignee
+        self.labels = labels
+        self.milestone = milestone
+        self.authoredByMe = authoredByMe
+        self.assignedToMe = assignedToMe
+    }
+
+    public var normalizedSearchText: String? {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+
+    public var normalizedAuthor: String? {
+        if authoredByMe {
+            return "@me"
+        }
+        return author?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+
+    public var normalizedAssignee: String? {
+        if assignedToMe {
+            return "@me"
+        }
+        return assignee?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+
+    public var normalizedLabels: [String] {
+        labels.compactMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty }
+    }
+
+    public var normalizedMilestone: String? {
+        milestone?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+}
+
+public struct WorkspaceGitHubReviewFilter: Equatable, Sendable {
+    public static let defaultLimit = 50
+
+    public var limit: Int
+    public var state: WorkspaceGitHubReviewFilterState
+    public var searchText: String
+    public var author: String?
+    public var labels: [String]
+    public var scope: WorkspaceGitHubReviewScope
+
+    public init(
+        limit: Int = WorkspaceGitHubReviewFilter.defaultLimit,
+        state: WorkspaceGitHubReviewFilterState = .open,
+        searchText: String = "",
+        author: String? = nil,
+        labels: [String] = [],
+        scope: WorkspaceGitHubReviewScope = .requestedToMe
+    ) {
+        self.limit = max(1, limit)
+        self.state = state
+        self.searchText = searchText
+        self.author = author
+        self.labels = labels
+        self.scope = scope
+    }
+
+    public var normalizedSearchText: String? {
+        searchText.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+
+    public var normalizedAuthor: String? {
+        author?.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty
+    }
+
+    public var normalizedLabels: [String] {
+        labels.compactMap { $0.trimmingCharacters(in: .whitespacesAndNewlines).nilIfEmpty }
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/macos/Sources/DevHavenCore/Models/WorkspaceGitHubModels.swift
+++ b/macos/Sources/DevHavenCore/Models/WorkspaceGitHubModels.swift
@@ -221,6 +221,59 @@ public struct WorkspaceGitHubComment: Codable, Equatable, Sendable, Identifiable
     }
 }
 
+public enum WorkspaceGitHubPullMergeMethod: String, CaseIterable, Identifiable, Sendable {
+    case merge
+
+    public var id: String { rawValue }
+
+    public var ghArgument: String {
+        switch self {
+        case .merge:
+            return "--merge"
+        }
+    }
+
+    public var title: String {
+        switch self {
+        case .merge:
+            return "Merge"
+        }
+    }
+}
+
+public enum WorkspaceGitHubReviewSubmissionEvent: String, CaseIterable, Identifiable, Sendable {
+    case comment
+    case approve
+    case requestChanges
+
+    public var id: String { rawValue }
+
+    public var ghArgument: String {
+        switch self {
+        case .comment:
+            return "--comment"
+        case .approve:
+            return "--approve"
+        case .requestChanges:
+            return "--request-changes"
+        }
+    }
+}
+
+public enum WorkspaceGitHubMutationKind: Equatable, Sendable {
+    case addIssueComment
+    case closeIssue
+    case reopenIssue
+    case createIssueBranch
+    case createIssueWorktree
+    case addPullComment
+    case closePull
+    case reopenPull
+    case mergePull(WorkspaceGitHubPullMergeMethod)
+    case checkoutPullBranch
+    case submitReview(WorkspaceGitHubReviewSubmissionEvent)
+}
+
 public struct WorkspaceGitHubCommitAuthor: Codable, Equatable, Sendable {
     public var nodeID: String?
     public var login: String?
@@ -669,6 +722,10 @@ public struct WorkspaceGitHubIssueSummary: Equatable, Sendable, Identifiable {
         self.updatedAt = updatedAt
         self.url = url
     }
+
+    public var suggestedBranchName: String {
+        GitHubIssueBranchNameBuilder.suggestedBranchName(number: number, title: title)
+    }
 }
 
 public struct WorkspaceGitHubIssueDetail: Equatable, Sendable, Identifiable {
@@ -690,6 +747,10 @@ public struct WorkspaceGitHubIssueDetail: Equatable, Sendable, Identifiable {
 
     public var commentsCount: Int {
         comments.count
+    }
+
+    public var suggestedBranchName: String {
+        GitHubIssueBranchNameBuilder.suggestedBranchName(number: number, title: title)
     }
 
     public init(
@@ -724,6 +785,27 @@ public struct WorkspaceGitHubIssueDetail: Equatable, Sendable, Identifiable {
         self.closedAt = closedAt
         self.url = url
         self.comments = comments
+    }
+}
+
+public enum GitHubIssueBranchNameBuilder {
+    public static func suggestedBranchName(number: Int, title: String) -> String {
+        let foldedTitle = title
+            .folding(options: [.diacriticInsensitive, .caseInsensitive], locale: .current)
+            .lowercased()
+        let slug = foldedTitle
+            .replacingOccurrences(
+                of: #"[^a-z0-9]+"#,
+                with: "-",
+                options: .regularExpression
+            )
+            .trimmingCharacters(in: CharacterSet(charactersIn: "-"))
+        let trimmedSlug = slug
+            .split(separator: "-")
+            .prefix(6)
+            .joined(separator: "-")
+        let fallbackSlug = trimmedSlug.isEmpty ? "issue" : trimmedSlug
+        return "issue/\(number)-\(fallbackSlug)"
     }
 }
 
@@ -772,6 +854,7 @@ public enum WorkspaceGitHubCommandError: LocalizedError, Equatable, Sendable {
     case unsupportedRemote(String)
     case authRequired(String)
     case parseFailure(String)
+    case operationRejected(String)
     case commandFailed(command: String, message: String)
     case timedOut(command: String, timeout: TimeInterval)
 
@@ -784,6 +867,8 @@ public enum WorkspaceGitHubCommandError: LocalizedError, Equatable, Sendable {
         case let .authRequired(message):
             return message
         case let .parseFailure(message):
+            return message
+        case let .operationRejected(message):
             return message
         case let .commandFailed(command, message):
             return "GitHub 命令执行失败（\(command)）：\(message)"

--- a/macos/Sources/DevHavenCore/Models/WorkspaceGitHubModels.swift
+++ b/macos/Sources/DevHavenCore/Models/WorkspaceGitHubModels.swift
@@ -1,0 +1,794 @@
+import Foundation
+
+public enum WorkspaceGitHubSection: String, CaseIterable, Identifiable, Sendable {
+    case pulls
+    case issues
+    case reviews
+
+    public var id: String { rawValue }
+
+    public var title: String {
+        switch self {
+        case .pulls:
+            return "Pull Requests"
+        case .issues:
+            return "Issues"
+        case .reviews:
+            return "Reviews"
+        }
+    }
+}
+
+public struct WorkspaceGitHubRepositoryContext: Equatable, Sendable {
+    public var rootProjectPath: String
+    public var repositoryPath: String
+    public var remoteName: String
+    public var remoteURL: String
+    public var host: String
+    public var owner: String
+    public var name: String
+
+    public var repositoryFullName: String {
+        "\(owner)/\(name)"
+    }
+
+    public var repoSelector: String {
+        if host.caseInsensitiveCompare("github.com") == .orderedSame {
+            return repositoryFullName
+        }
+        return "\(host)/\(repositoryFullName)"
+    }
+
+    public init(
+        rootProjectPath: String,
+        repositoryPath: String,
+        remoteName: String,
+        remoteURL: String,
+        host: String,
+        owner: String,
+        name: String
+    ) {
+        self.rootProjectPath = rootProjectPath
+        self.repositoryPath = repositoryPath
+        self.remoteName = remoteName
+        self.remoteURL = remoteURL
+        self.host = host
+        self.owner = owner
+        self.name = name
+    }
+}
+
+public enum WorkspaceGitHubAuthState: String, Equatable, Sendable {
+    case unknown
+    case authenticated
+    case unauthenticated
+}
+
+public struct WorkspaceGitHubAuthStatus: Equatable, Sendable {
+    public var host: String
+    public var state: WorkspaceGitHubAuthState
+    public var activeLogin: String?
+    public var gitProtocol: String?
+    public var tokenSource: String?
+    public var scopes: [String]
+
+    public var isAuthenticated: Bool {
+        state == .authenticated
+    }
+
+    public var summaryText: String {
+        switch state {
+        case .unknown:
+            return "尚未检查 GitHub 登录状态"
+        case .authenticated:
+            if let activeLogin, !activeLogin.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                return "已登录 GitHub：\(activeLogin)"
+            }
+            return "已登录 GitHub"
+        case .unauthenticated:
+            return "未登录 GitHub CLI"
+        }
+    }
+
+    public init(
+        host: String,
+        state: WorkspaceGitHubAuthState,
+        activeLogin: String? = nil,
+        gitProtocol: String? = nil,
+        tokenSource: String? = nil,
+        scopes: [String] = []
+    ) {
+        self.host = host
+        self.state = state
+        self.activeLogin = activeLogin
+        self.gitProtocol = gitProtocol
+        self.tokenSource = tokenSource
+        self.scopes = scopes
+    }
+
+    public static func unchecked(host: String) -> WorkspaceGitHubAuthStatus {
+        WorkspaceGitHubAuthStatus(host: host, state: .unknown)
+    }
+}
+
+public struct WorkspaceGitHubActor: Codable, Equatable, Hashable, Sendable {
+    public var nodeID: String?
+    public var login: String?
+    public var name: String?
+    public var isBot: Bool
+    public var url: String?
+
+    public var displayName: String {
+        if let name, !name.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return name
+        }
+        if let login, !login.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+            return login
+        }
+        return "未知用户"
+    }
+
+    public init(
+        nodeID: String? = nil,
+        login: String? = nil,
+        name: String? = nil,
+        isBot: Bool = false,
+        url: String? = nil
+    ) {
+        self.nodeID = nodeID
+        self.login = login
+        self.name = name
+        self.isBot = isBot
+        self.url = url
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case nodeID = "id"
+        case login
+        case name
+        case isBot
+        case url
+    }
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.nodeID = try container.decodeIfPresent(String.self, forKey: .nodeID)
+        self.login = try container.decodeIfPresent(String.self, forKey: .login)
+        self.name = try container.decodeIfPresent(String.self, forKey: .name)
+        self.isBot = try container.decodeIfPresent(Bool.self, forKey: .isBot) ?? false
+        self.url = try container.decodeIfPresent(String.self, forKey: .url)
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.container(keyedBy: CodingKeys.self)
+        try container.encodeIfPresent(nodeID, forKey: .nodeID)
+        try container.encodeIfPresent(login, forKey: .login)
+        try container.encodeIfPresent(name, forKey: .name)
+        try container.encode(isBot, forKey: .isBot)
+        try container.encodeIfPresent(url, forKey: .url)
+    }
+}
+
+public struct WorkspaceGitHubLabel: Codable, Equatable, Hashable, Sendable, Identifiable {
+    public var id: String { name }
+    public var name: String
+    public var color: String?
+    public var description: String?
+
+    public init(name: String, color: String? = nil, description: String? = nil) {
+        self.name = name
+        self.color = color
+        self.description = description
+    }
+}
+
+public struct WorkspaceGitHubMilestone: Codable, Equatable, Sendable {
+    public var title: String
+    public var number: Int?
+    public var description: String?
+    public var dueOn: Date?
+
+    public init(title: String, number: Int? = nil, description: String? = nil, dueOn: Date? = nil) {
+        self.title = title
+        self.number = number
+        self.description = description
+        self.dueOn = dueOn
+    }
+}
+
+public struct WorkspaceGitHubComment: Codable, Equatable, Sendable, Identifiable {
+    public var id: String
+    public var author: WorkspaceGitHubActor?
+    public var authorAssociation: String?
+    public var body: String
+    public var createdAt: Date
+    public var url: String
+
+    public init(
+        id: String,
+        author: WorkspaceGitHubActor?,
+        authorAssociation: String? = nil,
+        body: String,
+        createdAt: Date,
+        url: String
+    ) {
+        self.id = id
+        self.author = author
+        self.authorAssociation = authorAssociation
+        self.body = body
+        self.createdAt = createdAt
+        self.url = url
+    }
+}
+
+public struct WorkspaceGitHubCommitAuthor: Codable, Equatable, Sendable {
+    public var nodeID: String?
+    public var login: String?
+    public var name: String?
+    public var email: String?
+
+    public init(nodeID: String? = nil, login: String? = nil, name: String? = nil, email: String? = nil) {
+        self.nodeID = nodeID
+        self.login = login
+        self.name = name
+        self.email = email
+    }
+
+    private enum CodingKeys: String, CodingKey {
+        case nodeID = "id"
+        case login
+        case name
+        case email
+    }
+}
+
+public struct WorkspaceGitHubCommitSummary: Codable, Equatable, Sendable, Identifiable {
+    public var id: String { oid }
+    public var oid: String
+    public var messageHeadline: String
+    public var messageBody: String?
+    public var authoredDate: Date?
+    public var committedDate: Date?
+    public var authors: [WorkspaceGitHubCommitAuthor]
+
+    public init(
+        oid: String,
+        messageHeadline: String,
+        messageBody: String? = nil,
+        authoredDate: Date? = nil,
+        committedDate: Date? = nil,
+        authors: [WorkspaceGitHubCommitAuthor] = []
+    ) {
+        self.oid = oid
+        self.messageHeadline = messageHeadline
+        self.messageBody = messageBody
+        self.authoredDate = authoredDate
+        self.committedDate = committedDate
+        self.authors = authors
+    }
+}
+
+public enum WorkspaceGitHubPullState: Codable, Equatable, Sendable {
+    case open
+    case closed
+    case merged
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        switch rawValue.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() {
+        case "OPEN":
+            self = .open
+        case "CLOSED":
+            self = .closed
+        case "MERGED":
+            self = .merged
+        default:
+            self = .unknown(rawValue)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .open:
+            return "OPEN"
+        case .closed:
+            return "CLOSED"
+        case .merged:
+            return "MERGED"
+        case let .unknown(value):
+            return value
+        }
+    }
+}
+
+public enum WorkspaceGitHubIssueState: Codable, Equatable, Sendable {
+    case open
+    case closed
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        switch rawValue.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() {
+        case "OPEN":
+            self = .open
+        case "CLOSED":
+            self = .closed
+        default:
+            self = .unknown(rawValue)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .open:
+            return "OPEN"
+        case .closed:
+            return "CLOSED"
+        case let .unknown(value):
+            return value
+        }
+    }
+}
+
+public enum WorkspaceGitHubIssueStateReason: Codable, Equatable, Sendable {
+    case completed
+    case notPlanned
+    case reopened
+    case none
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = (try? container.decode(String.self)) ?? ""
+        let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        switch normalized {
+        case "":
+            self = .none
+        case "COMPLETED":
+            self = .completed
+        case "NOT_PLANNED":
+            self = .notPlanned
+        case "REOPENED":
+            self = .reopened
+        default:
+            self = .unknown(rawValue)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .completed:
+            return "COMPLETED"
+        case .notPlanned:
+            return "NOT_PLANNED"
+        case .reopened:
+            return "REOPENED"
+        case .none:
+            return ""
+        case let .unknown(value):
+            return value
+        }
+    }
+}
+
+public enum WorkspaceGitHubReviewDecision: Codable, Equatable, Sendable {
+    case none
+    case approved
+    case changesRequested
+    case reviewRequired
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = (try? container.decode(String.self)) ?? ""
+        let normalized = rawValue.trimmingCharacters(in: .whitespacesAndNewlines).uppercased()
+        switch normalized {
+        case "":
+            self = .none
+        case "APPROVED":
+            self = .approved
+        case "CHANGES_REQUESTED":
+            self = .changesRequested
+        case "REVIEW_REQUIRED":
+            self = .reviewRequired
+        default:
+            self = .unknown(rawValue)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .none:
+            return ""
+        case .approved:
+            return "APPROVED"
+        case .changesRequested:
+            return "CHANGES_REQUESTED"
+        case .reviewRequired:
+            return "REVIEW_REQUIRED"
+        case let .unknown(value):
+            return value
+        }
+    }
+}
+
+public enum WorkspaceGitHubMergeStateStatus: Codable, Equatable, Sendable {
+    case clean
+    case blocked
+    case behind
+    case dirty
+    case draft
+    case hasHooks
+    case unstable
+    case unknown(String)
+
+    public init(from decoder: Decoder) throws {
+        let container = try decoder.singleValueContainer()
+        let rawValue = try container.decode(String.self)
+        switch rawValue.trimmingCharacters(in: .whitespacesAndNewlines).uppercased() {
+        case "CLEAN":
+            self = .clean
+        case "BLOCKED":
+            self = .blocked
+        case "BEHIND":
+            self = .behind
+        case "DIRTY":
+            self = .dirty
+        case "DRAFT":
+            self = .draft
+        case "HAS_HOOKS":
+            self = .hasHooks
+        case "UNSTABLE":
+            self = .unstable
+        default:
+            self = .unknown(rawValue)
+        }
+    }
+
+    public func encode(to encoder: Encoder) throws {
+        var container = encoder.singleValueContainer()
+        try container.encode(rawValue)
+    }
+
+    public var rawValue: String {
+        switch self {
+        case .clean:
+            return "CLEAN"
+        case .blocked:
+            return "BLOCKED"
+        case .behind:
+            return "BEHIND"
+        case .dirty:
+            return "DIRTY"
+        case .draft:
+            return "DRAFT"
+        case .hasHooks:
+            return "HAS_HOOKS"
+        case .unstable:
+            return "UNSTABLE"
+        case let .unknown(value):
+            return value
+        }
+    }
+}
+
+public struct WorkspaceGitHubPullSummary: Equatable, Sendable, Identifiable {
+    public var id: String
+    public var number: Int
+    public var title: String
+    public var state: WorkspaceGitHubPullState
+    public var isDraft: Bool
+    public var author: WorkspaceGitHubActor?
+    public var assignees: [WorkspaceGitHubActor]
+    public var labels: [WorkspaceGitHubLabel]
+    public var commentsCount: Int
+    public var reviewDecision: WorkspaceGitHubReviewDecision
+    public var createdAt: Date
+    public var updatedAt: Date
+    public var url: String
+    public var headRefName: String
+    public var baseRefName: String
+
+    public init(
+        id: String,
+        number: Int,
+        title: String,
+        state: WorkspaceGitHubPullState,
+        isDraft: Bool,
+        author: WorkspaceGitHubActor?,
+        assignees: [WorkspaceGitHubActor] = [],
+        labels: [WorkspaceGitHubLabel] = [],
+        commentsCount: Int = 0,
+        reviewDecision: WorkspaceGitHubReviewDecision = .none,
+        createdAt: Date,
+        updatedAt: Date,
+        url: String,
+        headRefName: String,
+        baseRefName: String
+    ) {
+        self.id = id
+        self.number = number
+        self.title = title
+        self.state = state
+        self.isDraft = isDraft
+        self.author = author
+        self.assignees = assignees
+        self.labels = labels
+        self.commentsCount = commentsCount
+        self.reviewDecision = reviewDecision
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.url = url
+        self.headRefName = headRefName
+        self.baseRefName = baseRefName
+    }
+}
+
+public struct WorkspaceGitHubPullDetail: Equatable, Sendable, Identifiable {
+    public var id: String
+    public var number: Int
+    public var title: String
+    public var state: WorkspaceGitHubPullState
+    public var isDraft: Bool
+    public var author: WorkspaceGitHubActor?
+    public var assignees: [WorkspaceGitHubActor]
+    public var labels: [WorkspaceGitHubLabel]
+    public var reviewDecision: WorkspaceGitHubReviewDecision
+    public var mergeStateStatus: WorkspaceGitHubMergeStateStatus
+    public var milestone: WorkspaceGitHubMilestone?
+    public var body: String?
+    public var createdAt: Date
+    public var updatedAt: Date
+    public var mergedAt: Date?
+    public var mergedBy: WorkspaceGitHubActor?
+    public var url: String
+    public var headRefName: String
+    public var baseRefName: String
+    public var changedFiles: Int
+    public var comments: [WorkspaceGitHubComment]
+    public var commits: [WorkspaceGitHubCommitSummary]
+
+    public var commentsCount: Int {
+        comments.count
+    }
+
+    public var commitCount: Int {
+        commits.count
+    }
+
+    public init(
+        id: String,
+        number: Int,
+        title: String,
+        state: WorkspaceGitHubPullState,
+        isDraft: Bool,
+        author: WorkspaceGitHubActor?,
+        assignees: [WorkspaceGitHubActor] = [],
+        labels: [WorkspaceGitHubLabel] = [],
+        reviewDecision: WorkspaceGitHubReviewDecision = .none,
+        mergeStateStatus: WorkspaceGitHubMergeStateStatus = .unknown("UNKNOWN"),
+        milestone: WorkspaceGitHubMilestone? = nil,
+        body: String? = nil,
+        createdAt: Date,
+        updatedAt: Date,
+        mergedAt: Date? = nil,
+        mergedBy: WorkspaceGitHubActor? = nil,
+        url: String,
+        headRefName: String,
+        baseRefName: String,
+        changedFiles: Int = 0,
+        comments: [WorkspaceGitHubComment] = [],
+        commits: [WorkspaceGitHubCommitSummary] = []
+    ) {
+        self.id = id
+        self.number = number
+        self.title = title
+        self.state = state
+        self.isDraft = isDraft
+        self.author = author
+        self.assignees = assignees
+        self.labels = labels
+        self.reviewDecision = reviewDecision
+        self.mergeStateStatus = mergeStateStatus
+        self.milestone = milestone
+        self.body = body
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.mergedAt = mergedAt
+        self.mergedBy = mergedBy
+        self.url = url
+        self.headRefName = headRefName
+        self.baseRefName = baseRefName
+        self.changedFiles = changedFiles
+        self.comments = comments
+        self.commits = commits
+    }
+}
+
+public struct WorkspaceGitHubIssueSummary: Equatable, Sendable, Identifiable {
+    public var id: String
+    public var number: Int
+    public var title: String
+    public var state: WorkspaceGitHubIssueState
+    public var stateReason: WorkspaceGitHubIssueStateReason
+    public var author: WorkspaceGitHubActor?
+    public var assignees: [WorkspaceGitHubActor]
+    public var labels: [WorkspaceGitHubLabel]
+    public var commentsCount: Int
+    public var createdAt: Date
+    public var updatedAt: Date
+    public var url: String
+
+    public init(
+        id: String,
+        number: Int,
+        title: String,
+        state: WorkspaceGitHubIssueState,
+        stateReason: WorkspaceGitHubIssueStateReason = .none,
+        author: WorkspaceGitHubActor?,
+        assignees: [WorkspaceGitHubActor] = [],
+        labels: [WorkspaceGitHubLabel] = [],
+        commentsCount: Int = 0,
+        createdAt: Date,
+        updatedAt: Date,
+        url: String
+    ) {
+        self.id = id
+        self.number = number
+        self.title = title
+        self.state = state
+        self.stateReason = stateReason
+        self.author = author
+        self.assignees = assignees
+        self.labels = labels
+        self.commentsCount = commentsCount
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.url = url
+    }
+}
+
+public struct WorkspaceGitHubIssueDetail: Equatable, Sendable, Identifiable {
+    public var id: String
+    public var number: Int
+    public var title: String
+    public var state: WorkspaceGitHubIssueState
+    public var stateReason: WorkspaceGitHubIssueStateReason
+    public var author: WorkspaceGitHubActor?
+    public var assignees: [WorkspaceGitHubActor]
+    public var labels: [WorkspaceGitHubLabel]
+    public var milestone: WorkspaceGitHubMilestone?
+    public var body: String?
+    public var createdAt: Date
+    public var updatedAt: Date
+    public var closedAt: Date?
+    public var url: String
+    public var comments: [WorkspaceGitHubComment]
+
+    public var commentsCount: Int {
+        comments.count
+    }
+
+    public init(
+        id: String,
+        number: Int,
+        title: String,
+        state: WorkspaceGitHubIssueState,
+        stateReason: WorkspaceGitHubIssueStateReason = .none,
+        author: WorkspaceGitHubActor?,
+        assignees: [WorkspaceGitHubActor] = [],
+        labels: [WorkspaceGitHubLabel] = [],
+        milestone: WorkspaceGitHubMilestone? = nil,
+        body: String? = nil,
+        createdAt: Date,
+        updatedAt: Date,
+        closedAt: Date? = nil,
+        url: String,
+        comments: [WorkspaceGitHubComment] = []
+    ) {
+        self.id = id
+        self.number = number
+        self.title = title
+        self.state = state
+        self.stateReason = stateReason
+        self.author = author
+        self.assignees = assignees
+        self.labels = labels
+        self.milestone = milestone
+        self.body = body
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.closedAt = closedAt
+        self.url = url
+        self.comments = comments
+    }
+}
+
+public struct WorkspaceGitHubReviewRequestSummary: Equatable, Sendable, Identifiable {
+    public var id: String
+    public var number: Int
+    public var title: String
+    public var state: WorkspaceGitHubPullState
+    public var isDraft: Bool
+    public var author: WorkspaceGitHubActor?
+    public var labels: [WorkspaceGitHubLabel]
+    public var commentsCount: Int
+    public var createdAt: Date
+    public var updatedAt: Date
+    public var url: String
+
+    public init(
+        id: String,
+        number: Int,
+        title: String,
+        state: WorkspaceGitHubPullState,
+        isDraft: Bool,
+        author: WorkspaceGitHubActor?,
+        labels: [WorkspaceGitHubLabel] = [],
+        commentsCount: Int = 0,
+        createdAt: Date,
+        updatedAt: Date,
+        url: String
+    ) {
+        self.id = id
+        self.number = number
+        self.title = title
+        self.state = state
+        self.isDraft = isDraft
+        self.author = author
+        self.labels = labels
+        self.commentsCount = commentsCount
+        self.createdAt = createdAt
+        self.updatedAt = updatedAt
+        self.url = url
+    }
+}
+
+public enum WorkspaceGitHubCommandError: LocalizedError, Equatable, Sendable {
+    case invalidRepository(String)
+    case unsupportedRemote(String)
+    case authRequired(String)
+    case parseFailure(String)
+    case commandFailed(command: String, message: String)
+    case timedOut(command: String, timeout: TimeInterval)
+
+    public var errorDescription: String? {
+        switch self {
+        case let .invalidRepository(message):
+            return message
+        case let .unsupportedRemote(message):
+            return message
+        case let .authRequired(message):
+            return message
+        case let .parseFailure(message):
+            return message
+        case let .commandFailed(command, message):
+            return "GitHub 命令执行失败（\(command)）：\(message)"
+        case let .timedOut(command, timeout):
+            return "GitHub 命令超时（\(command)，\(Int(timeout)) 秒）"
+        }
+    }
+}

--- a/macos/Sources/DevHavenCore/Models/WorkspaceGitModels.swift
+++ b/macos/Sources/DevHavenCore/Models/WorkspaceGitModels.swift
@@ -4,6 +4,7 @@ public enum WorkspaceToolWindowKind: String, CaseIterable, Identifiable, Sendabl
     case project
     case commit
     case git
+    case github
 
     public var id: String { rawValue }
 
@@ -14,6 +15,8 @@ public enum WorkspaceToolWindowKind: String, CaseIterable, Identifiable, Sendabl
         case .commit:
             return .side
         case .git:
+            return .bottom
+        case .github:
             return .bottom
         }
     }
@@ -26,6 +29,8 @@ public enum WorkspaceToolWindowKind: String, CaseIterable, Identifiable, Sendabl
             return "Commit"
         case .git:
             return "Git"
+        case .github:
+            return "GitHub"
         }
     }
 
@@ -37,6 +42,8 @@ public enum WorkspaceToolWindowKind: String, CaseIterable, Identifiable, Sendabl
             return "checkmark.circle"
         case .git:
             return "point.3.connected.trianglepath.dotted"
+        case .github:
+            return "chevron.left.forwardslash.chevron.right"
         }
     }
 }

--- a/macos/Sources/DevHavenCore/Storage/NativeGitHubCommandRunner.swift
+++ b/macos/Sources/DevHavenCore/Storage/NativeGitHubCommandRunner.swift
@@ -1,0 +1,180 @@
+import Foundation
+
+public struct NativeGitHubCommandRunner: Sendable {
+    private final class PipeBuffer: @unchecked Sendable {
+        private let lock = NSLock()
+        private var storage = Data()
+
+        func append(_ chunk: Data) {
+            lock.lock()
+            storage.append(chunk)
+            lock.unlock()
+        }
+
+        func data() -> Data {
+            lock.lock()
+            defer { lock.unlock() }
+            return storage
+        }
+    }
+
+    public struct Result: Equatable, Sendable {
+        public var command: [String]
+        public var stdout: String
+        public var stderr: String
+        public var exitCode: Int32
+
+        public init(command: [String], stdout: String, stderr: String, exitCode: Int32) {
+            self.command = command
+            self.stdout = stdout
+            self.stderr = stderr
+            self.exitCode = exitCode
+        }
+
+        public var isSuccess: Bool {
+            exitCode == 0
+        }
+
+        public var errorMessage: String {
+            let trimmedStderr = stderr.trimmingCharacters(in: .whitespacesAndNewlines)
+            if !trimmedStderr.isEmpty {
+                return trimmedStderr
+            }
+            let trimmedStdout = stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+            return trimmedStdout.isEmpty ? "未知错误" : trimmedStdout
+        }
+    }
+
+    public var defaultTimeout: TimeInterval
+
+    public init(defaultTimeout: TimeInterval = 30) {
+        self.defaultTimeout = defaultTimeout
+    }
+
+    public func run(
+        arguments: [String],
+        at repositoryPath: String,
+        timeout: TimeInterval? = nil,
+        environment: [String: String] = [:]
+    ) throws -> Result {
+        let result = try runAllowingFailure(
+            arguments: arguments,
+            at: repositoryPath,
+            timeout: timeout,
+            environment: environment
+        )
+        guard result.isSuccess else {
+            throw mapFailure(result, timeout: timeout ?? defaultTimeout)
+        }
+        return result
+    }
+
+    public func runAllowingFailure(
+        arguments: [String],
+        at repositoryPath: String,
+        timeout: TimeInterval? = nil,
+        environment: [String: String] = [:]
+    ) throws -> Result {
+        let repositoryURL = URL(fileURLWithPath: repositoryPath, isDirectory: true)
+        guard FileManager.default.fileExists(atPath: repositoryURL.path) else {
+            throw WorkspaceGitHubCommandError.invalidRepository("仓库路径不存在：\(repositoryPath)")
+        }
+
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: "/usr/bin/env")
+        process.arguments = ["gh"] + arguments
+        process.currentDirectoryURL = repositoryURL
+
+        var mergedEnvironment = ProcessInfo.processInfo.environment
+        mergedEnvironment["GH_PAGER"] = "cat"
+        mergedEnvironment["PAGER"] = "cat"
+        mergedEnvironment["NO_COLOR"] = "1"
+        mergedEnvironment["CLICOLOR"] = "0"
+        mergedEnvironment["GH_NO_UPDATE_NOTIFIER"] = "1"
+        mergedEnvironment["GH_PROMPT_DISABLED"] = "1"
+        for (key, value) in environment {
+            mergedEnvironment[key] = value
+        }
+        process.environment = mergedEnvironment
+
+        let stdoutPipe = Pipe()
+        let stderrPipe = Pipe()
+        process.standardOutput = stdoutPipe
+        process.standardError = stderrPipe
+
+        do {
+            try process.run()
+        } catch {
+            throw WorkspaceGitHubCommandError.commandFailed(
+                command: (["/usr/bin/env", "gh"] + arguments).joined(separator: " "),
+                message: error.localizedDescription
+            )
+        }
+
+        let stdoutBuffer = PipeBuffer()
+        let stderrBuffer = PipeBuffer()
+
+        stdoutPipe.fileHandleForReading.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            guard !chunk.isEmpty else {
+                handle.readabilityHandler = nil
+                return
+            }
+            stdoutBuffer.append(chunk)
+        }
+
+        stderrPipe.fileHandleForReading.readabilityHandler = { handle in
+            let chunk = handle.availableData
+            guard !chunk.isEmpty else {
+                handle.readabilityHandler = nil
+                return
+            }
+            stderrBuffer.append(chunk)
+        }
+
+        let effectiveTimeout = timeout ?? defaultTimeout
+        var didTimeout = false
+        if effectiveTimeout > 0 {
+            let deadline = Date().addingTimeInterval(effectiveTimeout)
+            while process.isRunning && Date() < deadline {
+                Thread.sleep(forTimeInterval: 0.02)
+            }
+            if process.isRunning {
+                didTimeout = true
+                process.terminate()
+            }
+        }
+        process.waitUntilExit()
+        stdoutPipe.fileHandleForReading.readabilityHandler = nil
+        stderrPipe.fileHandleForReading.readabilityHandler = nil
+
+        stdoutBuffer.append(stdoutPipe.fileHandleForReading.readDataToEndOfFile())
+        stderrBuffer.append(stderrPipe.fileHandleForReading.readDataToEndOfFile())
+
+        if didTimeout {
+            throw WorkspaceGitHubCommandError.timedOut(
+                command: (["/usr/bin/env", "gh"] + arguments).joined(separator: " "),
+                timeout: effectiveTimeout
+            )
+        }
+
+        let stdout = String(data: stdoutBuffer.data(), encoding: .utf8) ?? ""
+        let stderr = String(data: stderrBuffer.data(), encoding: .utf8) ?? ""
+        return Result(
+            command: ["/usr/bin/env", "gh"] + arguments,
+            stdout: stdout,
+            stderr: stderr,
+            exitCode: process.terminationStatus
+        )
+    }
+
+    private func mapFailure(_ result: Result, timeout: TimeInterval) -> WorkspaceGitHubCommandError {
+        let command = result.command.joined(separator: " ")
+        let message = result.errorMessage
+        let normalized = message.lowercased()
+        if normalized.contains("authenticate") || normalized.contains("not logged into") {
+            return .authRequired("GitHub CLI 未登录，请先执行 gh auth login")
+        }
+        return .commandFailed(command: command, message: message)
+    }
+}

--- a/macos/Sources/DevHavenCore/Storage/NativeGitHubCommandRunner.swift
+++ b/macos/Sources/DevHavenCore/Storage/NativeGitHubCommandRunner.swift
@@ -1,6 +1,8 @@
 import Foundation
 
 public struct NativeGitHubCommandRunner: Sendable {
+    typealias Execution = @Sendable (_ arguments: [String], _ repositoryPath: String, _ timeout: TimeInterval?, _ environment: [String: String]) throws -> Result
+
     private final class PipeBuffer: @unchecked Sendable {
         private let lock = NSLock()
         private var storage = Data()
@@ -46,9 +48,19 @@ public struct NativeGitHubCommandRunner: Sendable {
     }
 
     public var defaultTimeout: TimeInterval
+    private let executeOverride: Execution?
 
     public init(defaultTimeout: TimeInterval = 30) {
         self.defaultTimeout = defaultTimeout
+        self.executeOverride = nil
+    }
+
+    init(
+        defaultTimeout: TimeInterval = 30,
+        executeOverride: Execution?
+    ) {
+        self.defaultTimeout = defaultTimeout
+        self.executeOverride = executeOverride
     }
 
     public func run(
@@ -75,6 +87,10 @@ public struct NativeGitHubCommandRunner: Sendable {
         timeout: TimeInterval? = nil,
         environment: [String: String] = [:]
     ) throws -> Result {
+        if let executeOverride {
+            return try executeOverride(arguments, repositoryPath, timeout, environment)
+        }
+
         let repositoryURL = URL(fileURLWithPath: repositoryPath, isDirectory: true)
         guard FileManager.default.fileExists(atPath: repositoryURL.path) else {
             throw WorkspaceGitHubCommandError.invalidRepository("仓库路径不存在：\(repositoryPath)")

--- a/macos/Sources/DevHavenCore/Storage/NativeGitHubRepositoryService.swift
+++ b/macos/Sources/DevHavenCore/Storage/NativeGitHubRepositoryService.swift
@@ -1,0 +1,488 @@
+import Foundation
+
+public struct NativeGitHubRepositoryService: Sendable {
+    private let runner: NativeGitHubCommandRunner
+    private let remoteResolver: WorkspaceGitHubRemoteResolver
+
+    public init(
+        runner: NativeGitHubCommandRunner = NativeGitHubCommandRunner(),
+        remoteResolver: WorkspaceGitHubRemoteResolver = WorkspaceGitHubRemoteResolver()
+    ) {
+        self.runner = runner
+        self.remoteResolver = remoteResolver
+    }
+
+    public func resolveRepositoryContext(
+        rootProjectPath: String,
+        repositoryPath: String,
+        preferredRemoteName: String? = nil
+    ) throws -> WorkspaceGitHubRepositoryContext {
+        try remoteResolver.resolveRepositoryContext(
+            rootProjectPath: rootProjectPath,
+            repositoryPath: repositoryPath,
+            preferredRemoteName: preferredRemoteName
+        )
+    }
+
+    public func checkAuthStatus(host: String) throws -> WorkspaceGitHubAuthStatus {
+        let response: GitHubAuthStatusResponse = try runJSON(
+            GitHubAuthStatusResponse.self,
+            arguments: [
+                "auth",
+                "status",
+                "--active",
+                "--hostname",
+                host,
+                "--json",
+                "hosts",
+            ],
+            at: FileManager.default.homeDirectoryForCurrentUser.path
+        )
+
+        guard let account = response.hosts[host]?.first else {
+            return WorkspaceGitHubAuthStatus(host: host, state: .unauthenticated)
+        }
+
+        let state = account.state.trimmingCharacters(in: .whitespacesAndNewlines).lowercased() == "success"
+            ? WorkspaceGitHubAuthState.authenticated
+            : WorkspaceGitHubAuthState.unauthenticated
+        let scopes = account.scopes?
+            .split(separator: ",")
+            .map { String($0).trimmingCharacters(in: .whitespacesAndNewlines) }
+            .filter { !$0.isEmpty } ?? []
+        return WorkspaceGitHubAuthStatus(
+            host: host,
+            state: state,
+            activeLogin: account.login,
+            gitProtocol: account.gitProtocol,
+            tokenSource: account.tokenSource,
+            scopes: scopes
+        )
+    }
+
+    public func loadPulls(
+        in context: WorkspaceGitHubRepositoryContext,
+        filter: WorkspaceGitHubPullFilter = WorkspaceGitHubPullFilter()
+    ) throws -> [WorkspaceGitHubPullSummary] {
+        var arguments = [
+            "pr",
+            "list",
+            "-R",
+            context.repoSelector,
+            "--limit",
+            String(filter.limit),
+            "--state",
+            filter.state.ghArgument,
+            "--json",
+            "id,number,title,state,isDraft,author,assignees,labels,comments,reviewDecision,createdAt,updatedAt,url,headRefName,baseRefName",
+        ]
+
+        if filter.draftOnly {
+            arguments.append("--draft")
+        }
+        if let author = filter.normalizedAuthor {
+            arguments += ["--author", author]
+        }
+        if let assignee = filter.normalizedAssignee {
+            arguments += ["--assignee", assignee]
+        }
+        if let baseBranch = filter.normalizedBaseBranch {
+            arguments += ["--base", baseBranch]
+        }
+        if let headBranch = filter.normalizedHeadBranch {
+            arguments += ["--head", headBranch]
+        }
+        for label in filter.normalizedLabels {
+            arguments += ["--label", label]
+        }
+        if let searchText = filter.normalizedSearchText {
+            arguments += ["--search", searchText]
+        }
+
+        let payload: [PullListDTO] = try runJSON([PullListDTO].self, arguments: arguments, at: context.repositoryPath)
+        return payload.map { dto in
+            WorkspaceGitHubPullSummary(
+                id: dto.id,
+                number: dto.number,
+                title: dto.title,
+                state: dto.state,
+                isDraft: dto.isDraft,
+                author: dto.author,
+                assignees: dto.assignees ?? [],
+                labels: dto.labels,
+                commentsCount: dto.comments?.count ?? 0,
+                reviewDecision: dto.reviewDecision,
+                createdAt: dto.createdAt,
+                updatedAt: dto.updatedAt,
+                url: dto.url,
+                headRefName: dto.headRefName,
+                baseRefName: dto.baseRefName
+            )
+        }
+    }
+
+    public func loadIssues(
+        in context: WorkspaceGitHubRepositoryContext,
+        filter: WorkspaceGitHubIssueFilter = WorkspaceGitHubIssueFilter()
+    ) throws -> [WorkspaceGitHubIssueSummary] {
+        var arguments = [
+            "issue",
+            "list",
+            "-R",
+            context.repoSelector,
+            "--limit",
+            String(filter.limit),
+            "--state",
+            filter.state.ghArgument,
+            "--json",
+            "id,number,title,state,stateReason,author,assignees,labels,comments,createdAt,updatedAt,url,milestone",
+        ]
+
+        if let author = filter.normalizedAuthor {
+            arguments += ["--author", author]
+        }
+        if let assignee = filter.normalizedAssignee {
+            arguments += ["--assignee", assignee]
+        }
+        if let milestone = filter.normalizedMilestone {
+            arguments += ["--milestone", milestone]
+        }
+        for label in filter.normalizedLabels {
+            arguments += ["--label", label]
+        }
+        if let searchText = filter.normalizedSearchText {
+            arguments += ["--search", searchText]
+        }
+
+        let payload: [IssueListDTO] = try runJSON([IssueListDTO].self, arguments: arguments, at: context.repositoryPath)
+        return payload.map { dto in
+            WorkspaceGitHubIssueSummary(
+                id: dto.id,
+                number: dto.number,
+                title: dto.title,
+                state: dto.state,
+                stateReason: dto.stateReason ?? .none,
+                author: dto.author,
+                assignees: dto.assignees ?? [],
+                labels: dto.labels,
+                commentsCount: dto.comments?.count ?? 0,
+                createdAt: dto.createdAt,
+                updatedAt: dto.updatedAt,
+                url: dto.url
+            )
+        }
+    }
+
+    public func loadReviewRequests(
+        in context: WorkspaceGitHubRepositoryContext,
+        filter: WorkspaceGitHubReviewFilter = WorkspaceGitHubReviewFilter()
+    ) throws -> [WorkspaceGitHubReviewRequestSummary] {
+        var arguments = ["search", "prs"]
+        if let searchText = filter.normalizedSearchText {
+            arguments.append(searchText)
+        }
+        arguments += [
+            "--repo",
+            context.repoSelector,
+            "--state",
+            filter.state.ghArgument,
+            "--limit",
+            String(filter.limit),
+            "--json",
+            "id,number,title,state,isDraft,author,labels,commentsCount,createdAt,updatedAt,url",
+        ]
+
+        switch filter.scope {
+        case .requestedToMe:
+            arguments += ["--review-requested", "@me"]
+        case .involvingMe:
+            arguments += ["--involves", "@me"]
+        }
+
+        if let author = filter.normalizedAuthor {
+            arguments += ["--author", author]
+        }
+        for label in filter.normalizedLabels {
+            arguments += ["--label", label]
+        }
+
+        let payload: [ReviewSearchDTO] = try runJSON([ReviewSearchDTO].self, arguments: arguments, at: context.repositoryPath)
+        return payload.map { dto in
+            WorkspaceGitHubReviewRequestSummary(
+                id: dto.id,
+                number: dto.number,
+                title: dto.title,
+                state: dto.state,
+                isDraft: dto.isDraft,
+                author: dto.author,
+                labels: dto.labels,
+                commentsCount: dto.commentsCount,
+                createdAt: dto.createdAt,
+                updatedAt: dto.updatedAt,
+                url: dto.url
+            )
+        }
+    }
+
+    public func loadPullDetail(
+        in context: WorkspaceGitHubRepositoryContext,
+        number: Int
+    ) throws -> WorkspaceGitHubPullDetail {
+        let payload: PullDetailDTO = try runJSON(
+            PullDetailDTO.self,
+            arguments: [
+                "pr",
+                "view",
+                String(number),
+                "-R",
+                context.repoSelector,
+                "--json",
+                "id,number,title,state,isDraft,author,assignees,labels,reviewDecision,mergeStateStatus,milestone,body,createdAt,updatedAt,mergedAt,mergedBy,url,headRefName,baseRefName,changedFiles,comments,commits",
+            ],
+            at: context.repositoryPath
+        )
+
+        return WorkspaceGitHubPullDetail(
+            id: payload.id,
+            number: payload.number,
+            title: payload.title,
+            state: payload.state,
+            isDraft: payload.isDraft,
+            author: payload.author,
+            assignees: payload.assignees ?? [],
+            labels: payload.labels,
+            reviewDecision: payload.reviewDecision,
+            mergeStateStatus: payload.mergeStateStatus,
+            milestone: payload.milestone,
+            body: payload.body?.nilIfEmpty,
+            createdAt: payload.createdAt,
+            updatedAt: payload.updatedAt,
+            mergedAt: payload.mergedAt,
+            mergedBy: payload.mergedBy,
+            url: payload.url,
+            headRefName: payload.headRefName,
+            baseRefName: payload.baseRefName,
+            changedFiles: payload.changedFiles,
+            comments: payload.comments?.map(\.model) ?? [],
+            commits: payload.commits ?? []
+        )
+    }
+
+    public func loadIssueDetail(
+        in context: WorkspaceGitHubRepositoryContext,
+        number: Int
+    ) throws -> WorkspaceGitHubIssueDetail {
+        let payload: IssueDetailDTO = try runJSON(
+            IssueDetailDTO.self,
+            arguments: [
+                "issue",
+                "view",
+                String(number),
+                "-R",
+                context.repoSelector,
+                "--json",
+                "id,number,title,state,stateReason,author,assignees,labels,milestone,body,createdAt,updatedAt,closedAt,url,comments",
+            ],
+            at: context.repositoryPath
+        )
+
+        return WorkspaceGitHubIssueDetail(
+            id: payload.id,
+            number: payload.number,
+            title: payload.title,
+            state: payload.state,
+            stateReason: payload.stateReason ?? .none,
+            author: payload.author,
+            assignees: payload.assignees ?? [],
+            labels: payload.labels,
+            milestone: payload.milestone,
+            body: payload.body?.nilIfEmpty,
+            createdAt: payload.createdAt,
+            updatedAt: payload.updatedAt,
+            closedAt: payload.closedAt,
+            url: payload.url,
+            comments: payload.comments?.map(\.model) ?? []
+        )
+    }
+
+    private func runJSON<T: Decodable>(
+        _ type: T.Type,
+        arguments: [String],
+        at repositoryPath: String
+    ) throws -> T {
+        let result = try runner.runAllowingFailure(arguments: arguments, at: repositoryPath)
+        guard result.isSuccess else {
+            throw mapFailure(result)
+        }
+        let output = result.stdout.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !output.isEmpty else {
+            throw WorkspaceGitHubCommandError.parseFailure("GitHub 命令未返回可解析数据")
+        }
+        let data = Data(output.utf8)
+        do {
+            return try makeDecoder().decode(T.self, from: data)
+        } catch {
+            throw WorkspaceGitHubCommandError.parseFailure("GitHub 数据解析失败：\(error.localizedDescription)")
+        }
+    }
+
+    private func mapFailure(_ result: NativeGitHubCommandRunner.Result) -> WorkspaceGitHubCommandError {
+        let command = result.command.joined(separator: " ")
+        let message = result.errorMessage
+        let normalized = message.lowercased()
+        if normalized.contains("not logged into")
+            || normalized.contains("authenticate")
+            || normalized.contains("gh auth login")
+        {
+            return .authRequired("GitHub CLI 未登录，请先执行 gh auth login")
+        }
+        if normalized.contains("could not resolve to a repository")
+            || normalized.contains("no git remotes configured")
+            || normalized.contains("none of the git remotes configured")
+        {
+            return .unsupportedRemote("当前仓库未能解析为 GitHub 仓库，请检查 remote 配置")
+        }
+        return .commandFailed(command: command, message: message)
+    }
+
+    private func makeDecoder() -> JSONDecoder {
+        let decoder = JSONDecoder()
+        decoder.keyDecodingStrategy = .convertFromSnakeCase
+        decoder.dateDecodingStrategy = .iso8601
+        return decoder
+    }
+}
+
+private struct GitHubAuthStatusResponse: Decodable {
+    let hosts: [String: [GitHubAuthAccountDTO]]
+}
+
+private struct GitHubAuthAccountDTO: Decodable {
+    let state: String
+    let login: String?
+    let tokenSource: String?
+    let scopes: String?
+    let gitProtocol: String?
+}
+
+private struct PullListDTO: Decodable {
+    let id: String
+    let number: Int
+    let title: String
+    let state: WorkspaceGitHubPullState
+    let isDraft: Bool
+    let author: WorkspaceGitHubActor?
+    let assignees: [WorkspaceGitHubActor]?
+    let labels: [WorkspaceGitHubLabel]
+    let comments: [CommentCountDTO]?
+    let reviewDecision: WorkspaceGitHubReviewDecision
+    let createdAt: Date
+    let updatedAt: Date
+    let url: String
+    let headRefName: String
+    let baseRefName: String
+}
+
+private struct IssueListDTO: Decodable {
+    let id: String
+    let number: Int
+    let title: String
+    let state: WorkspaceGitHubIssueState
+    let stateReason: WorkspaceGitHubIssueStateReason?
+    let author: WorkspaceGitHubActor?
+    let assignees: [WorkspaceGitHubActor]?
+    let labels: [WorkspaceGitHubLabel]
+    let comments: [CommentCountDTO]?
+    let createdAt: Date
+    let updatedAt: Date
+    let url: String
+    let milestone: WorkspaceGitHubMilestone?
+}
+
+private struct ReviewSearchDTO: Decodable {
+    let id: String
+    let number: Int
+    let title: String
+    let state: WorkspaceGitHubPullState
+    let isDraft: Bool
+    let author: WorkspaceGitHubActor?
+    let labels: [WorkspaceGitHubLabel]
+    let commentsCount: Int
+    let createdAt: Date
+    let updatedAt: Date
+    let url: String
+}
+
+private struct PullDetailDTO: Decodable {
+    let id: String
+    let number: Int
+    let title: String
+    let state: WorkspaceGitHubPullState
+    let isDraft: Bool
+    let author: WorkspaceGitHubActor?
+    let assignees: [WorkspaceGitHubActor]?
+    let labels: [WorkspaceGitHubLabel]
+    let reviewDecision: WorkspaceGitHubReviewDecision
+    let mergeStateStatus: WorkspaceGitHubMergeStateStatus
+    let milestone: WorkspaceGitHubMilestone?
+    let body: String?
+    let createdAt: Date
+    let updatedAt: Date
+    let mergedAt: Date?
+    let mergedBy: WorkspaceGitHubActor?
+    let url: String
+    let headRefName: String
+    let baseRefName: String
+    let changedFiles: Int
+    let comments: [CommentDTO]?
+    let commits: [WorkspaceGitHubCommitSummary]?
+}
+
+private struct IssueDetailDTO: Decodable {
+    let id: String
+    let number: Int
+    let title: String
+    let state: WorkspaceGitHubIssueState
+    let stateReason: WorkspaceGitHubIssueStateReason?
+    let author: WorkspaceGitHubActor?
+    let assignees: [WorkspaceGitHubActor]?
+    let labels: [WorkspaceGitHubLabel]
+    let milestone: WorkspaceGitHubMilestone?
+    let body: String?
+    let createdAt: Date
+    let updatedAt: Date
+    let closedAt: Date?
+    let url: String
+    let comments: [CommentDTO]?
+}
+
+private struct CommentCountDTO: Decodable {
+    let id: String?
+}
+
+private struct CommentDTO: Decodable {
+    let id: String
+    let author: WorkspaceGitHubActor?
+    let authorAssociation: String?
+    let body: String
+    let createdAt: Date
+    let url: String
+
+    var model: WorkspaceGitHubComment {
+        WorkspaceGitHubComment(
+            id: id,
+            author: author,
+            authorAssociation: authorAssociation,
+            body: body,
+            createdAt: createdAt,
+            url: url
+        )
+    }
+}
+
+private extension String {
+    var nilIfEmpty: String? {
+        let trimmed = trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmed.isEmpty ? nil : trimmed
+    }
+}

--- a/macos/Sources/DevHavenCore/Storage/NativeGitHubRepositoryService.swift
+++ b/macos/Sources/DevHavenCore/Storage/NativeGitHubRepositoryService.swift
@@ -305,6 +305,174 @@ public struct NativeGitHubRepositoryService: Sendable {
         )
     }
 
+    public func addIssueComment(
+        in context: WorkspaceGitHubRepositoryContext,
+        number: Int,
+        body: String
+    ) throws {
+        try runVoid(
+            arguments: [
+                "issue",
+                "comment",
+                String(number),
+                "-R",
+                context.repoSelector,
+                "--body",
+                try normalizedCommentBody(body, emptyMessage: "评论内容不能为空"),
+            ],
+            at: context.repositoryPath
+        )
+    }
+
+    public func closeIssue(
+        in context: WorkspaceGitHubRepositoryContext,
+        number: Int
+    ) throws {
+        try runVoid(
+            arguments: [
+                "issue",
+                "close",
+                String(number),
+                "-R",
+                context.repoSelector,
+            ],
+            at: context.repositoryPath
+        )
+    }
+
+    public func reopenIssue(
+        in context: WorkspaceGitHubRepositoryContext,
+        number: Int
+    ) throws {
+        try runVoid(
+            arguments: [
+                "issue",
+                "reopen",
+                String(number),
+                "-R",
+                context.repoSelector,
+            ],
+            at: context.repositoryPath
+        )
+    }
+
+    public func addPullComment(
+        in context: WorkspaceGitHubRepositoryContext,
+        number: Int,
+        body: String
+    ) throws {
+        try runVoid(
+            arguments: [
+                "pr",
+                "comment",
+                String(number),
+                "-R",
+                context.repoSelector,
+                "--body",
+                try normalizedCommentBody(body, emptyMessage: "评论内容不能为空"),
+            ],
+            at: context.repositoryPath
+        )
+    }
+
+    public func closePull(
+        in context: WorkspaceGitHubRepositoryContext,
+        number: Int
+    ) throws {
+        try runVoid(
+            arguments: [
+                "pr",
+                "close",
+                String(number),
+                "-R",
+                context.repoSelector,
+            ],
+            at: context.repositoryPath
+        )
+    }
+
+    public func reopenPull(
+        in context: WorkspaceGitHubRepositoryContext,
+        number: Int
+    ) throws {
+        try runVoid(
+            arguments: [
+                "pr",
+                "reopen",
+                String(number),
+                "-R",
+                context.repoSelector,
+            ],
+            at: context.repositoryPath
+        )
+    }
+
+    public func mergePull(
+        in context: WorkspaceGitHubRepositoryContext,
+        number: Int,
+        method: WorkspaceGitHubPullMergeMethod = .merge
+    ) throws {
+        try runVoid(
+            arguments: [
+                "pr",
+                "merge",
+                String(number),
+                "-R",
+                context.repoSelector,
+                method.ghArgument,
+            ],
+            at: context.repositoryPath,
+            timeout: 90
+        )
+    }
+
+    public func checkoutPullBranch(
+        in context: WorkspaceGitHubRepositoryContext,
+        number: Int,
+        at executionPath: String
+    ) throws {
+        try runVoid(
+            arguments: [
+                "pr",
+                "checkout",
+                String(number),
+                "-R",
+                context.repoSelector,
+            ],
+            at: executionPath,
+            timeout: 90
+        )
+    }
+
+    public func submitReview(
+        in context: WorkspaceGitHubRepositoryContext,
+        number: Int,
+        event: WorkspaceGitHubReviewSubmissionEvent,
+        body: String?
+    ) throws {
+        let normalizedBody = body?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        if (event == .comment || event == .requestChanges),
+           normalizedBody?.isEmpty != false {
+            throw WorkspaceGitHubCommandError.operationRejected(
+                event == .comment ? "Review 评论内容不能为空" : "请求修改时请填写说明"
+            )
+        }
+
+        var arguments = [
+            "pr",
+            "review",
+            String(number),
+            "-R",
+            context.repoSelector,
+            event.ghArgument,
+        ]
+        if let normalizedBody, !normalizedBody.isEmpty {
+            arguments += ["--body", normalizedBody]
+        }
+        try runVoid(arguments: arguments, at: context.repositoryPath, timeout: 90)
+    }
+
     private func runJSON<T: Decodable>(
         _ type: T.Type,
         arguments: [String],
@@ -324,6 +492,32 @@ public struct NativeGitHubRepositoryService: Sendable {
         } catch {
             throw WorkspaceGitHubCommandError.parseFailure("GitHub 数据解析失败：\(error.localizedDescription)")
         }
+    }
+
+    private func runVoid(
+        arguments: [String],
+        at repositoryPath: String,
+        timeout: TimeInterval? = nil
+    ) throws {
+        let result = try runner.runAllowingFailure(
+            arguments: arguments,
+            at: repositoryPath,
+            timeout: timeout
+        )
+        guard result.isSuccess else {
+            throw mapFailure(result)
+        }
+    }
+
+    private func normalizedCommentBody(
+        _ body: String,
+        emptyMessage: String
+    ) throws -> String {
+        let normalizedBody = body.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedBody.isEmpty else {
+            throw WorkspaceGitHubCommandError.operationRejected(emptyMessage)
+        }
+        return normalizedBody
     }
 
     private func mapFailure(_ result: NativeGitHubCommandRunner.Result) -> WorkspaceGitHubCommandError {

--- a/macos/Sources/DevHavenCore/Storage/WorkspaceGitHubRemoteResolver.swift
+++ b/macos/Sources/DevHavenCore/Storage/WorkspaceGitHubRemoteResolver.swift
@@ -1,0 +1,125 @@
+import Foundation
+
+public struct WorkspaceGitHubRemoteResolver: Sendable {
+    private let gitService: NativeGitRepositoryService
+
+    public init(gitService: NativeGitRepositoryService = NativeGitRepositoryService()) {
+        self.gitService = gitService
+    }
+
+    public func resolveRepositoryContext(
+        rootProjectPath: String,
+        repositoryPath: String,
+        preferredRemoteName: String? = nil
+    ) throws -> WorkspaceGitHubRepositoryContext {
+        let remotes = try gitService.loadRemotes(at: repositoryPath)
+        guard !remotes.isEmpty else {
+            throw WorkspaceGitHubCommandError.unsupportedRemote("当前仓库未配置 remote，无法解析 GitHub 仓库")
+        }
+
+        let preferredName = preferredRemoteName?.trimmingCharacters(in: .whitespacesAndNewlines)
+        let orderedRemotes = remotes.sorted { lhs, rhs in
+            if lhs.name == preferredName { return true }
+            if rhs.name == preferredName { return false }
+            if lhs.name == "origin" { return true }
+            if rhs.name == "origin" { return false }
+            return lhs.name.localizedStandardCompare(rhs.name) == .orderedAscending
+        }
+
+        for remote in orderedRemotes {
+            guard let remoteURL = remote.fetchURL ?? remote.pushURL,
+                  let parsed = parseRemote(remoteURL)
+            else {
+                continue
+            }
+            return WorkspaceGitHubRepositoryContext(
+                rootProjectPath: rootProjectPath,
+                repositoryPath: repositoryPath,
+                remoteName: remote.name,
+                remoteURL: remoteURL,
+                host: parsed.host,
+                owner: parsed.owner,
+                name: parsed.repository
+            )
+        }
+
+        throw WorkspaceGitHubCommandError.unsupportedRemote("未找到可解析的 GitHub remote，请确认仓库 remote 指向 GitHub")
+    }
+
+    private func parseRemote(_ rawRemoteURL: String) -> ParsedRemote? {
+        let trimmedURL = rawRemoteURL.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !trimmedURL.isEmpty else {
+            return nil
+        }
+
+        if let url = URL(string: trimmedURL), let host = url.host {
+            let normalizedHost = normalizeHost(host)
+            let pathComponents = url.path
+                .split(separator: "/")
+                .map(String.init)
+                .filter { !$0.isEmpty }
+            guard pathComponents.count >= 2 else {
+                return nil
+            }
+            let owner = pathComponents[0]
+            let repository = sanitizeRepositoryName(pathComponents[1])
+            guard !owner.isEmpty, !repository.isEmpty else {
+                return nil
+            }
+            return ParsedRemote(host: normalizedHost, owner: owner, repository: repository)
+        }
+
+        let pattern = #"^(?:[^@]+@)?([^:\/]+):(.+)$"#
+        guard let expression = try? NSRegularExpression(pattern: pattern) else {
+            return nil
+        }
+        let range = NSRange(location: 0, length: trimmedURL.utf16.count)
+        guard let match = expression.firstMatch(in: trimmedURL, range: range),
+              match.numberOfRanges == 3,
+              let hostRange = Range(match.range(at: 1), in: trimmedURL),
+              let pathRange = Range(match.range(at: 2), in: trimmedURL)
+        else {
+            return nil
+        }
+
+        let host = normalizeHost(String(trimmedURL[hostRange]))
+        let path = String(trimmedURL[pathRange])
+        let pathComponents = path
+            .split(separator: "/")
+            .map(String.init)
+            .filter { !$0.isEmpty }
+        guard pathComponents.count >= 2 else {
+            return nil
+        }
+        let owner = pathComponents[0]
+        let repository = sanitizeRepositoryName(pathComponents[1])
+        guard !owner.isEmpty, !repository.isEmpty else {
+            return nil
+        }
+        return ParsedRemote(host: host, owner: owner, repository: repository)
+    }
+
+    private func sanitizeRepositoryName(_ value: String) -> String {
+        let trimmed = value.trimmingCharacters(in: .whitespacesAndNewlines)
+        if trimmed.hasSuffix(".git") {
+            return String(trimmed.dropLast(4))
+        }
+        return trimmed
+    }
+
+    private func normalizeHost(_ host: String) -> String {
+        let trimmed = host.trimmingCharacters(in: .whitespacesAndNewlines).lowercased()
+        switch trimmed {
+        case "ssh.github.com":
+            return "github.com"
+        default:
+            return trimmed
+        }
+    }
+}
+
+private struct ParsedRemote: Equatable, Sendable {
+    var host: String
+    var owner: String
+    var repository: String
+}

--- a/macos/Sources/DevHavenCore/ViewModels/NativeAppViewModel.swift
+++ b/macos/Sources/DevHavenCore/ViewModels/NativeAppViewModel.swift
@@ -148,6 +148,7 @@ public final class NativeAppViewModel {
     @ObservationIgnored private let worktreeService: any NativeWorktreeServicing
     @ObservationIgnored private let worktreeEnvironmentService: any NativeWorktreeEnvironmentServicing
     @ObservationIgnored private let gitRepositoryService: NativeGitRepositoryService
+    @ObservationIgnored private let gitHubRepositoryService: NativeGitHubRepositoryService
     @ObservationIgnored private let workspaceFileSystemService: WorkspaceFileSystemService
     @ObservationIgnored private let agentSignalStore: WorkspaceAgentSignalStore
     @ObservationIgnored private let runManager: any WorkspaceRunManaging
@@ -311,6 +312,7 @@ public final class NativeAppViewModel {
     }
     private var workspaceCommitViewModels: [String: WorkspaceCommitViewModel]
     private var workspaceGitViewModels: [String: WorkspaceGitViewModel]
+    private var workspaceGitHubViewModels: [String: WorkspaceGitHubViewModel]
     private var workspaceDiffTabViewModels: [String: WorkspaceDiffTabViewModel]
     public private(set) var workspaceSidebarProjectionRevision: Int
     public private(set) var codexDisplayCandidatesRevision: Int
@@ -353,6 +355,7 @@ public final class NativeAppViewModel {
         worktreeService: (any NativeWorktreeServicing)? = nil,
         worktreeEnvironmentService: (any NativeWorktreeEnvironmentServicing)? = nil,
         gitRepositoryService: NativeGitRepositoryService = NativeGitRepositoryService(),
+        gitHubRepositoryService: NativeGitHubRepositoryService = NativeGitHubRepositoryService(),
         workspaceFileSystemService: WorkspaceFileSystemService = WorkspaceFileSystemService(),
         agentSignalStore: WorkspaceAgentSignalStore? = nil,
         runManager: (any WorkspaceRunManaging)? = nil,
@@ -372,6 +375,7 @@ public final class NativeAppViewModel {
         self.worktreeService = worktreeService ?? NativeGitWorktreeService()
         self.worktreeEnvironmentService = worktreeEnvironmentService ?? NativeWorktreeEnvironmentService()
         self.gitRepositoryService = gitRepositoryService
+        self.gitHubRepositoryService = gitHubRepositoryService
         self.workspaceFileSystemService = workspaceFileSystemService
         self.agentSignalStore = agentSignalStore ?? WorkspaceAgentSignalStore(
             baseDirectoryURL: store.agentStatusSessionsDirectoryURL
@@ -412,6 +416,7 @@ public final class NativeAppViewModel {
         self.workspaceAlignmentStatusByKey = [:]
         self.workspaceCommitViewModels = [:]
         self.workspaceGitViewModels = [:]
+        self.workspaceGitHubViewModels = [:]
         self.workspaceDiffTabViewModels = [:]
         self.workspaceSidebarProjectionRevision = 0
         self.codexDisplayCandidatesRevision = 0
@@ -1401,6 +1406,13 @@ public final class NativeAppViewModel {
         return workspaceGitViewModels[rootProjectPath]
     }
 
+    public var activeWorkspaceGitHubViewModel: WorkspaceGitHubViewModel? {
+        guard let rootProjectPath = activeWorkspaceRootProjectPath else {
+            return nil
+        }
+        return workspaceGitHubViewModels[rootProjectPath]
+    }
+
     public var activeWorkspaceState: WorkspaceSessionState? {
         activeWorkspaceController?.sessionState
     }
@@ -2327,6 +2339,25 @@ public final class NativeAppViewModel {
         workspaceCommitViewModels[rootProject.path] = WorkspaceCommitViewModel(
             repositoryContext: repositoryContext,
             client: .live(service: gitRepositoryService)
+        )
+    }
+
+    public func prepareActiveWorkspaceGitHubViewModel() {
+        guard let rootProject = activeWorkspaceRootProject,
+              rootProject.isGitRepository,
+              let repositoryContext = activeWorkspaceGitRepositoryContext
+        else {
+            return
+        }
+
+        if let existing = workspaceGitHubViewModels[rootProject.path] {
+            existing.updateRepositoryContext(repositoryContext)
+            return
+        }
+
+        workspaceGitHubViewModels[rootProject.path] = WorkspaceGitHubViewModel(
+            repositoryContext: repositoryContext,
+            client: .live(service: gitHubRepositoryService)
         )
     }
 
@@ -3665,6 +3696,8 @@ public final class NativeAppViewModel {
                 prepareActiveWorkspaceCommitViewModel()
             case .git:
                 prepareActiveWorkspaceGitViewModel()
+            case .github:
+                prepareActiveWorkspaceGitHubViewModel()
             }
         }
     }

--- a/macos/Sources/DevHavenCore/ViewModels/NativeAppViewModel.swift
+++ b/macos/Sources/DevHavenCore/ViewModels/NativeAppViewModel.swift
@@ -1367,6 +1367,14 @@ public final class NativeAppViewModel {
         return projectsByNormalizedPath[normalizedRootProjectPath]
     }
 
+    public var activeWorkspaceRootCurrentBranchName: String? {
+        guard let rootProject = activeWorkspaceRootProject else {
+            return nil
+        }
+        return currentBranchByProjectPath[rootProject.path]
+            ?? currentBranchByProjectPath[normalizePathForCompare(rootProject.path)]
+    }
+
     public var activeWorkspaceGitRepositoryContext: WorkspaceGitRepositoryContext? {
         guard let rootProject = activeWorkspaceRootProject,
               rootProject.isGitRepository
@@ -2349,15 +2357,20 @@ public final class NativeAppViewModel {
         else {
             return
         }
+        let executionPath = preferredWorkspaceGitExecutionPath(for: rootProject.path)
 
         if let existing = workspaceGitHubViewModels[rootProject.path] {
-            existing.updateRepositoryContext(repositoryContext)
+            existing.updateRepositoryContext(repositoryContext, executionPath: executionPath)
             return
         }
 
         workspaceGitHubViewModels[rootProject.path] = WorkspaceGitHubViewModel(
             repositoryContext: repositoryContext,
-            client: .live(service: gitHubRepositoryService)
+            executionPath: executionPath,
+            client: .live(
+                githubService: gitHubRepositoryService,
+                gitService: gitRepositoryService
+            )
         )
     }
 

--- a/macos/Sources/DevHavenCore/ViewModels/WorkspaceGitHubViewModel.swift
+++ b/macos/Sources/DevHavenCore/ViewModels/WorkspaceGitHubViewModel.swift
@@ -12,6 +12,17 @@ public final class WorkspaceGitHubViewModel {
         public var loadReviewRequests: @Sendable (WorkspaceGitHubRepositoryContext, WorkspaceGitHubReviewFilter) throws -> [WorkspaceGitHubReviewRequestSummary]
         public var loadPullDetail: @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> WorkspaceGitHubPullDetail
         public var loadIssueDetail: @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> WorkspaceGitHubIssueDetail
+        public var addIssueComment: @Sendable (WorkspaceGitHubRepositoryContext, Int, String) throws -> Void
+        public var closeIssue: @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> Void
+        public var reopenIssue: @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> Void
+        public var createLocalBranch: @Sendable (String, String, String?) throws -> Void
+        public var checkoutLocalBranch: @Sendable (String, String) throws -> Void
+        public var addPullComment: @Sendable (WorkspaceGitHubRepositoryContext, Int, String) throws -> Void
+        public var closePull: @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> Void
+        public var reopenPull: @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> Void
+        public var mergePull: @Sendable (WorkspaceGitHubRepositoryContext, Int, WorkspaceGitHubPullMergeMethod) throws -> Void
+        public var checkoutPullBranch: @Sendable (WorkspaceGitHubRepositoryContext, Int, String) throws -> Void
+        public var submitReview: @Sendable (WorkspaceGitHubRepositoryContext, Int, WorkspaceGitHubReviewSubmissionEvent, String?) throws -> Void
 
         public init(
             resolveRepositoryContext: @escaping @Sendable (WorkspaceGitRepositoryContext) throws -> WorkspaceGitHubRepositoryContext,
@@ -20,7 +31,18 @@ public final class WorkspaceGitHubViewModel {
             loadIssues: @escaping @Sendable (WorkspaceGitHubRepositoryContext, WorkspaceGitHubIssueFilter) throws -> [WorkspaceGitHubIssueSummary],
             loadReviewRequests: @escaping @Sendable (WorkspaceGitHubRepositoryContext, WorkspaceGitHubReviewFilter) throws -> [WorkspaceGitHubReviewRequestSummary],
             loadPullDetail: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> WorkspaceGitHubPullDetail,
-            loadIssueDetail: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> WorkspaceGitHubIssueDetail
+            loadIssueDetail: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> WorkspaceGitHubIssueDetail,
+            addIssueComment: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int, String) throws -> Void,
+            closeIssue: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> Void,
+            reopenIssue: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> Void,
+            createLocalBranch: @escaping @Sendable (String, String, String?) throws -> Void,
+            checkoutLocalBranch: @escaping @Sendable (String, String) throws -> Void,
+            addPullComment: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int, String) throws -> Void,
+            closePull: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> Void,
+            reopenPull: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> Void,
+            mergePull: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int, WorkspaceGitHubPullMergeMethod) throws -> Void,
+            checkoutPullBranch: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int, String) throws -> Void,
+            submitReview: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int, WorkspaceGitHubReviewSubmissionEvent, String?) throws -> Void
         ) {
             self.resolveRepositoryContext = resolveRepositoryContext
             self.loadAuthStatus = loadAuthStatus
@@ -29,22 +51,47 @@ public final class WorkspaceGitHubViewModel {
             self.loadReviewRequests = loadReviewRequests
             self.loadPullDetail = loadPullDetail
             self.loadIssueDetail = loadIssueDetail
+            self.addIssueComment = addIssueComment
+            self.closeIssue = closeIssue
+            self.reopenIssue = reopenIssue
+            self.createLocalBranch = createLocalBranch
+            self.checkoutLocalBranch = checkoutLocalBranch
+            self.addPullComment = addPullComment
+            self.closePull = closePull
+            self.reopenPull = reopenPull
+            self.mergePull = mergePull
+            self.checkoutPullBranch = checkoutPullBranch
+            self.submitReview = submitReview
         }
 
-        public static func live(service: NativeGitHubRepositoryService) -> Client {
+        public static func live(
+            githubService: NativeGitHubRepositoryService,
+            gitService: NativeGitRepositoryService
+        ) -> Client {
             Client(
                 resolveRepositoryContext: {
-                    try service.resolveRepositoryContext(
+                    try githubService.resolveRepositoryContext(
                         rootProjectPath: $0.rootProjectPath,
                         repositoryPath: $0.repositoryPath
                     )
                 },
-                loadAuthStatus: { (try? service.checkAuthStatus(host: $0.host)) ?? .unchecked(host: $0.host) },
-                loadPulls: { try service.loadPulls(in: $0, filter: $1) },
-                loadIssues: { try service.loadIssues(in: $0, filter: $1) },
-                loadReviewRequests: { try service.loadReviewRequests(in: $0, filter: $1) },
-                loadPullDetail: { try service.loadPullDetail(in: $0, number: $1) },
-                loadIssueDetail: { try service.loadIssueDetail(in: $0, number: $1) }
+                loadAuthStatus: { (try? githubService.checkAuthStatus(host: $0.host)) ?? .unchecked(host: $0.host) },
+                loadPulls: { try githubService.loadPulls(in: $0, filter: $1) },
+                loadIssues: { try githubService.loadIssues(in: $0, filter: $1) },
+                loadReviewRequests: { try githubService.loadReviewRequests(in: $0, filter: $1) },
+                loadPullDetail: { try githubService.loadPullDetail(in: $0, number: $1) },
+                loadIssueDetail: { try githubService.loadIssueDetail(in: $0, number: $1) },
+                addIssueComment: { try githubService.addIssueComment(in: $0, number: $1, body: $2) },
+                closeIssue: { try githubService.closeIssue(in: $0, number: $1) },
+                reopenIssue: { try githubService.reopenIssue(in: $0, number: $1) },
+                createLocalBranch: { try gitService.createBranch(name: $1, startPoint: $2, at: $0) },
+                checkoutLocalBranch: { try gitService.checkoutBranch(name: $1, at: $0) },
+                addPullComment: { try githubService.addPullComment(in: $0, number: $1, body: $2) },
+                closePull: { try githubService.closePull(in: $0, number: $1) },
+                reopenPull: { try githubService.reopenPull(in: $0, number: $1) },
+                mergePull: { try githubService.mergePull(in: $0, number: $1, method: $2) },
+                checkoutPullBranch: { try githubService.checkoutPullBranch(in: $0, number: $1, at: $2) },
+                submitReview: { try githubService.submitReview(in: $0, number: $1, event: $2, body: $3) }
             )
         }
     }
@@ -54,10 +101,12 @@ public final class WorkspaceGitHubViewModel {
     @ObservationIgnored private var refreshRevision = 0
     @ObservationIgnored private var detailTask: Task<Void, Never>?
     @ObservationIgnored private var detailRevision = 0
+    @ObservationIgnored private var mutationRevision = 0
     @ObservationIgnored private var pullDetailsByNumber: [Int: WorkspaceGitHubPullDetail] = [:]
     @ObservationIgnored private var issueDetailsByNumber: [Int: WorkspaceGitHubIssueDetail] = [:]
 
     public var repositoryContext: WorkspaceGitRepositoryContext
+    public var executionPath: String
     public private(set) var gitHubContext: WorkspaceGitHubRepositoryContext?
     public private(set) var authStatus: WorkspaceGitHubAuthStatus
     public var section: WorkspaceGitHubSection
@@ -73,15 +122,25 @@ public final class WorkspaceGitHubViewModel {
     public private(set) var selectedIssueDetail: WorkspaceGitHubIssueDetail?
     public private(set) var isLoading: Bool
     public private(set) var isLoadingDetail: Bool
+    public private(set) var isMutating: Bool
+    public private(set) var activeMutation: WorkspaceGitHubMutationKind?
+    public private(set) var lastSuccessfulMutation: WorkspaceGitHubMutationKind?
+    public private(set) var successfulMutationToken: Int
+    public var issueCommentDraft: String
+    public var pullCommentDraft: String
+    public var reviewCommentDraft: String
     public var errorMessage: String?
     public var detailErrorMessage: String?
+    public var mutationErrorMessage: String?
 
     public init(
         repositoryContext: WorkspaceGitRepositoryContext,
+        executionPath: String? = nil,
         section: WorkspaceGitHubSection = .pulls,
         client: Client
     ) {
         self.repositoryContext = repositoryContext
+        self.executionPath = executionPath ?? repositoryContext.repositoryPath
         self.client = client
         self.gitHubContext = nil
         self.authStatus = .unchecked(host: "github.com")
@@ -98,8 +157,16 @@ public final class WorkspaceGitHubViewModel {
         self.selectedIssueDetail = nil
         self.isLoading = false
         self.isLoadingDetail = false
+        self.isMutating = false
+        self.activeMutation = nil
+        self.lastSuccessfulMutation = nil
+        self.successfulMutationToken = 0
+        self.issueCommentDraft = ""
+        self.pullCommentDraft = ""
+        self.reviewCommentDraft = ""
         self.errorMessage = nil
         self.detailErrorMessage = nil
+        self.mutationErrorMessage = nil
     }
 
     deinit {
@@ -127,11 +194,17 @@ public final class WorkspaceGitHubViewModel {
         issues.first(where: { $0.number == selectedIssueNumber })
     }
 
-    public func updateRepositoryContext(_ repositoryContext: WorkspaceGitRepositoryContext) {
-        guard self.repositoryContext != repositoryContext else {
+    public func updateRepositoryContext(
+        _ repositoryContext: WorkspaceGitRepositoryContext,
+        executionPath: String? = nil
+    ) {
+        let nextExecutionPath = executionPath ?? repositoryContext.repositoryPath
+        guard self.repositoryContext != repositoryContext || self.executionPath != nextExecutionPath else {
             return
         }
+        mutationRevision += 1
         self.repositoryContext = repositoryContext
+        self.executionPath = nextExecutionPath
         gitHubContext = nil
         authStatus = .unchecked(host: "github.com")
         pulls = []
@@ -143,16 +216,33 @@ public final class WorkspaceGitHubViewModel {
         selectedIssueDetail = nil
         pullDetailsByNumber.removeAll()
         issueDetailsByNumber.removeAll()
+        issueCommentDraft = ""
+        pullCommentDraft = ""
+        reviewCommentDraft = ""
         errorMessage = nil
         detailErrorMessage = nil
+        mutationErrorMessage = nil
+        lastSuccessfulMutation = nil
+    }
+
+    public func updateExecutionPath(_ executionPath: String) {
+        let normalizedPath = executionPath.trimmingCharacters(in: .whitespacesAndNewlines)
+        guard !normalizedPath.isEmpty, self.executionPath != normalizedPath else {
+            return
+        }
+        mutationRevision += 1
+        self.executionPath = normalizedPath
     }
 
     public func setSection(_ section: WorkspaceGitHubSection) {
         guard self.section != section else {
             return
         }
+        mutationRevision += 1
         self.section = section
         detailErrorMessage = nil
+        mutationErrorMessage = nil
+        lastSuccessfulMutation = nil
         refreshIfNeeded()
     }
 
@@ -171,6 +261,7 @@ public final class WorkspaceGitHubViewModel {
 
     public func refresh() {
         refreshTask?.cancel()
+        mutationRevision += 1
         refreshRevision += 1
         let revision = refreshRevision
         let repositoryContext = repositoryContext
@@ -241,9 +332,14 @@ public final class WorkspaceGitHubViewModel {
         guard selectedPullNumber != number else {
             return
         }
+        mutationRevision += 1
         selectedPullNumber = number
         selectedPullDetail = nil
         detailErrorMessage = nil
+        mutationErrorMessage = nil
+        lastSuccessfulMutation = nil
+        pullCommentDraft = ""
+        reviewCommentDraft = ""
         guard let number else {
             isLoadingDetail = false
             detailTask?.cancel()
@@ -260,9 +356,13 @@ public final class WorkspaceGitHubViewModel {
         guard selectedIssueNumber != number else {
             return
         }
+        mutationRevision += 1
         selectedIssueNumber = number
         selectedIssueDetail = nil
         detailErrorMessage = nil
+        mutationErrorMessage = nil
+        lastSuccessfulMutation = nil
+        issueCommentDraft = ""
         guard let number else {
             isLoadingDetail = false
             detailTask?.cancel()
@@ -273,6 +373,131 @@ public final class WorkspaceGitHubViewModel {
             return
         }
         loadSelectedIssueDetail(number)
+    }
+
+    public func addCommentToSelectedIssue(body: String? = nil) {
+        let draft = body ?? issueCommentDraft
+        performIssueMutation(
+            kind: .addIssueComment,
+            refresh: .issue(number: selectedIssueNumber)
+        ) { client, gitHubContext, number, _ in
+            try client.addIssueComment(gitHubContext, number, draft)
+        } onSuccess: { [weak self] in
+            self?.issueCommentDraft = ""
+        }
+    }
+
+    public func closeSelectedIssue() {
+        performIssueMutation(
+            kind: .closeIssue,
+            refresh: .issue(number: selectedIssueNumber)
+        ) { client, gitHubContext, number, _ in
+            try client.closeIssue(gitHubContext, number)
+        }
+    }
+
+    public func reopenSelectedIssue() {
+        performIssueMutation(
+            kind: .reopenIssue,
+            refresh: .issue(number: selectedIssueNumber)
+        ) { client, gitHubContext, number, _ in
+            try client.reopenIssue(gitHubContext, number)
+        }
+    }
+
+    public func createAndCheckoutBranchForSelectedIssue() {
+        guard let detail = selectedIssueDetail ?? selectedIssueSummary.map(Self.makeIssueDetailFallback) else {
+            mutationErrorMessage = "请先选择一个 Issue"
+            return
+        }
+        let branchName = detail.suggestedBranchName
+        performIssueMutation(
+            kind: .createIssueBranch,
+            refresh: .none
+        ) { client, _, _, executionPath in
+            try client.createLocalBranch(executionPath, branchName, nil)
+            try client.checkoutLocalBranch(executionPath, branchName)
+        }
+    }
+
+    public func addCommentToSelectedPull(body: String? = nil) {
+        let draft = body ?? pullCommentDraft
+        performPullMutation(
+            kind: .addPullComment,
+            refresh: .pull(number: selectedPullNumber)
+        ) { client, gitHubContext, number, _ in
+            try client.addPullComment(gitHubContext, number, draft)
+        } onSuccess: { [weak self] in
+            self?.pullCommentDraft = ""
+        }
+    }
+
+    public func closeSelectedPull() {
+        performPullMutation(
+            kind: .closePull,
+            refresh: .pull(number: selectedPullNumber)
+        ) { client, gitHubContext, number, _ in
+            try client.closePull(gitHubContext, number)
+        }
+    }
+
+    public func reopenSelectedPull() {
+        performPullMutation(
+            kind: .reopenPull,
+            refresh: .pull(number: selectedPullNumber)
+        ) { client, gitHubContext, number, _ in
+            try client.reopenPull(gitHubContext, number)
+        }
+    }
+
+    public func mergeSelectedPull(method: WorkspaceGitHubPullMergeMethod = .merge) {
+        performPullMutation(
+            kind: .mergePull(method),
+            refresh: .pull(number: selectedPullNumber)
+        ) { client, gitHubContext, number, _ in
+            try client.mergePull(gitHubContext, number, method)
+        }
+    }
+
+    public func checkoutSelectedPullBranch() {
+        performPullMutation(
+            kind: .checkoutPullBranch,
+            refresh: .none
+        ) { client, gitHubContext, number, executionPath in
+            try client.checkoutPullBranch(gitHubContext, number, executionPath)
+        }
+    }
+
+    public func submitReviewForSelectedPull(
+        event: WorkspaceGitHubReviewSubmissionEvent,
+        body: String? = nil
+    ) {
+        let draft = body ?? reviewCommentDraft
+        performPullMutation(
+            kind: .submitReview(event),
+            refresh: .pull(number: selectedPullNumber)
+        ) { client, gitHubContext, number, _ in
+            try client.submitReview(gitHubContext, number, event, draft)
+        } onSuccess: { [weak self] in
+            self?.reviewCommentDraft = ""
+        }
+    }
+
+    public func reportMutationFailure(_ error: Error) {
+        mutationRevision += 1
+        isMutating = false
+        activeMutation = nil
+        mutationErrorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+        lastSuccessfulMutation = nil
+    }
+
+    public func reportExternalMutationSuccess(_ kind: WorkspaceGitHubMutationKind) {
+        mutationRevision += 1
+        isMutating = false
+        activeMutation = nil
+        mutationErrorMessage = nil
+        lastSuccessfulMutation = kind
+        successfulMutationToken += 1
     }
 
     private func selectDefaultDetailIfNeeded(forceReloadFor section: WorkspaceGitHubSection? = nil) {
@@ -392,11 +617,287 @@ public final class WorkspaceGitHubViewModel {
         }
     }
 
+    private func performIssueMutation(
+        kind: WorkspaceGitHubMutationKind,
+        refresh: MutationRefreshRequest,
+        _ mutation: @escaping @Sendable (Client, WorkspaceGitHubRepositoryContext, Int, String) throws -> Void,
+        onSuccess: (@MainActor () -> Void)? = nil
+    ) {
+        guard let gitHubContext else {
+            mutationErrorMessage = "GitHub 仓库上下文尚未就绪"
+            return
+        }
+        guard let number = selectedIssueNumber else {
+            mutationErrorMessage = "请先选择一个 Issue"
+            return
+        }
+        performMutation(
+            kind: kind,
+            gitHubContext: gitHubContext,
+            selectedIssueNumber: number,
+            selectedPullNumber: nil,
+            refresh: refresh,
+            mutation: mutation,
+            onSuccess: onSuccess
+        )
+    }
+
+    private func performPullMutation(
+        kind: WorkspaceGitHubMutationKind,
+        refresh: MutationRefreshRequest,
+        _ mutation: @escaping @Sendable (Client, WorkspaceGitHubRepositoryContext, Int, String) throws -> Void,
+        onSuccess: (@MainActor () -> Void)? = nil
+    ) {
+        guard let gitHubContext else {
+            mutationErrorMessage = "GitHub 仓库上下文尚未就绪"
+            return
+        }
+        guard let number = selectedPullNumber else {
+            mutationErrorMessage = "请先选择一个 Pull Request"
+            return
+        }
+        performMutation(
+            kind: kind,
+            gitHubContext: gitHubContext,
+            selectedIssueNumber: nil,
+            selectedPullNumber: number,
+            refresh: refresh,
+            mutation: mutation,
+            onSuccess: onSuccess
+        )
+    }
+
+    private func performMutation(
+        kind: WorkspaceGitHubMutationKind,
+        gitHubContext: WorkspaceGitHubRepositoryContext,
+        selectedIssueNumber: Int?,
+        selectedPullNumber: Int?,
+        refresh: MutationRefreshRequest,
+        mutation: @escaping @Sendable (Client, WorkspaceGitHubRepositoryContext, Int, String) throws -> Void,
+        onSuccess: (@MainActor () -> Void)?
+    ) {
+        guard !isMutating else {
+            return
+        }
+
+        let currentRepositoryContext = self.repositoryContext
+        let currentExecutionPath = self.executionPath
+        let currentSection = self.section
+        let currentPullFilter = self.pullFilter
+        let currentIssueFilter = self.issueFilter
+        let currentReviewFilter = self.reviewFilter
+
+        mutationRevision += 1
+        let revision = mutationRevision
+        isMutating = true
+        activeMutation = kind
+        mutationErrorMessage = nil
+        detailErrorMessage = nil
+        lastSuccessfulMutation = nil
+
+        Task { [client] in
+            do {
+                try await Task.detached(priority: .userInitiated) {
+                    let selectedNumber = selectedIssueNumber ?? selectedPullNumber ?? 0
+                    try mutation(client, gitHubContext, selectedNumber, currentExecutionPath)
+                }.value
+
+                let refreshedPayload: MutationRefreshPayload?
+                if refresh == .none {
+                    refreshedPayload = nil
+                } else {
+                    refreshedPayload = try await Task.detached(priority: .userInitiated) {
+                        try Self.loadMutationRefreshPayload(
+                            refresh: refresh,
+                            gitHubContext: gitHubContext,
+                            pullFilter: currentPullFilter,
+                            issueFilter: currentIssueFilter,
+                            reviewFilter: currentReviewFilter,
+                            client: client
+                        )
+                    }.value
+                }
+
+                await MainActor.run { [weak self] in
+                    guard let self else {
+                        return
+                    }
+                    guard self.mutationRevision == revision else {
+                        self.isMutating = false
+                        self.activeMutation = nil
+                        return
+                    }
+                    guard self.repositoryContext == currentRepositoryContext,
+                          self.executionPath == currentExecutionPath,
+                          self.pullFilter == currentPullFilter,
+                          self.issueFilter == currentIssueFilter,
+                          self.reviewFilter == currentReviewFilter
+                    else {
+                        self.isMutating = false
+                        self.activeMutation = nil
+                        return
+                    }
+
+                    if let refreshedPayload {
+                        self.applyMutationRefreshPayload(
+                            refreshedPayload,
+                            section: currentSection
+                        )
+                    }
+                    self.isMutating = false
+                    self.activeMutation = nil
+                    self.mutationErrorMessage = nil
+                    self.lastSuccessfulMutation = kind
+                    self.successfulMutationToken += 1
+                    onSuccess?()
+                }
+            } catch is CancellationError {
+                await MainActor.run { [weak self] in
+                    self?.isMutating = false
+                    self?.activeMutation = nil
+                }
+            } catch {
+                await MainActor.run { [weak self] in
+                    guard let self else {
+                        return
+                    }
+                    guard self.mutationRevision == revision else {
+                        self.isMutating = false
+                        self.activeMutation = nil
+                        return
+                    }
+                    self.isMutating = false
+                    self.activeMutation = nil
+                    self.mutationErrorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func applyMutationRefreshPayload(
+        _ payload: MutationRefreshPayload,
+        section: WorkspaceGitHubSection
+    ) {
+        guard section == self.section else {
+            return
+        }
+
+        pulls = payload.pulls
+        issues = payload.issues
+        reviewRequests = payload.reviewRequests
+
+        if let issueDetail = payload.issueDetail {
+            issueDetailsByNumber[issueDetail.number] = issueDetail
+        }
+        if let pullDetail = payload.pullDetail {
+            pullDetailsByNumber[pullDetail.number] = pullDetail
+        }
+        selectDefaultDetailIfNeeded(forceReloadFor: section)
+    }
+
+    private nonisolated static func loadMutationRefreshPayload(
+        refresh: MutationRefreshRequest,
+        gitHubContext: WorkspaceGitHubRepositoryContext,
+        pullFilter: WorkspaceGitHubPullFilter,
+        issueFilter: WorkspaceGitHubIssueFilter,
+        reviewFilter: WorkspaceGitHubReviewFilter,
+        client: Client
+    ) throws -> MutationRefreshPayload {
+        let pulls = try client.loadPulls(gitHubContext, pullFilter)
+        let issues = try client.loadIssues(gitHubContext, issueFilter)
+        let reviewRequests = try client.loadReviewRequests(gitHubContext, reviewFilter)
+
+        switch refresh {
+        case .none:
+            return MutationRefreshPayload(
+                pulls: pulls,
+                issues: issues,
+                reviewRequests: reviewRequests,
+                pullDetail: nil,
+                issueDetail: nil
+            )
+        case let .issue(number):
+            guard let number else {
+                return MutationRefreshPayload(
+                    pulls: pulls,
+                    issues: issues,
+                    reviewRequests: reviewRequests,
+                    pullDetail: nil,
+                    issueDetail: nil
+                )
+            }
+            let issueDetail = issues.contains(where: { $0.number == number })
+                ? try client.loadIssueDetail(gitHubContext, number)
+                : nil
+            return MutationRefreshPayload(
+                pulls: pulls,
+                issues: issues,
+                reviewRequests: reviewRequests,
+                pullDetail: nil,
+                issueDetail: issueDetail
+            )
+        case let .pull(number):
+            guard let number else {
+                return MutationRefreshPayload(
+                    pulls: pulls,
+                    issues: issues,
+                    reviewRequests: reviewRequests,
+                    pullDetail: nil,
+                    issueDetail: nil
+                )
+            }
+            let isVisibleInPullCollections = pulls.contains(where: { $0.number == number })
+                || reviewRequests.contains(where: { $0.number == number })
+            let pullDetail = isVisibleInPullCollections
+                ? try client.loadPullDetail(gitHubContext, number)
+                : nil
+            return MutationRefreshPayload(
+                pulls: pulls,
+                issues: issues,
+                reviewRequests: reviewRequests,
+                pullDetail: pullDetail,
+                issueDetail: nil
+            )
+        }
+    }
+
+    private nonisolated static func makeIssueDetailFallback(
+        from summary: WorkspaceGitHubIssueSummary
+    ) -> WorkspaceGitHubIssueDetail {
+        WorkspaceGitHubIssueDetail(
+            id: summary.id,
+            number: summary.number,
+            title: summary.title,
+            state: summary.state,
+            stateReason: summary.stateReason,
+            author: summary.author,
+            assignees: summary.assignees,
+            labels: summary.labels,
+            createdAt: summary.createdAt,
+            updatedAt: summary.updatedAt,
+            url: summary.url
+        )
+    }
+
     private struct RefreshPayload: Sendable {
         var gitHubContext: WorkspaceGitHubRepositoryContext
         var authStatus: WorkspaceGitHubAuthStatus
         var pulls: [WorkspaceGitHubPullSummary]
         var issues: [WorkspaceGitHubIssueSummary]
         var reviewRequests: [WorkspaceGitHubReviewRequestSummary]
+    }
+
+    private enum MutationRefreshRequest: Equatable, Sendable {
+        case none
+        case issue(number: Int?)
+        case pull(number: Int?)
+    }
+
+    private struct MutationRefreshPayload: Sendable {
+        var pulls: [WorkspaceGitHubPullSummary]
+        var issues: [WorkspaceGitHubIssueSummary]
+        var reviewRequests: [WorkspaceGitHubReviewRequestSummary]
+        var pullDetail: WorkspaceGitHubPullDetail?
+        var issueDetail: WorkspaceGitHubIssueDetail?
     }
 }

--- a/macos/Sources/DevHavenCore/ViewModels/WorkspaceGitHubViewModel.swift
+++ b/macos/Sources/DevHavenCore/ViewModels/WorkspaceGitHubViewModel.swift
@@ -1,0 +1,402 @@
+import Foundation
+import Observation
+
+@MainActor
+@Observable
+public final class WorkspaceGitHubViewModel {
+    public struct Client: Sendable {
+        public var resolveRepositoryContext: @Sendable (WorkspaceGitRepositoryContext) throws -> WorkspaceGitHubRepositoryContext
+        public var loadAuthStatus: @Sendable (WorkspaceGitHubRepositoryContext) -> WorkspaceGitHubAuthStatus
+        public var loadPulls: @Sendable (WorkspaceGitHubRepositoryContext, WorkspaceGitHubPullFilter) throws -> [WorkspaceGitHubPullSummary]
+        public var loadIssues: @Sendable (WorkspaceGitHubRepositoryContext, WorkspaceGitHubIssueFilter) throws -> [WorkspaceGitHubIssueSummary]
+        public var loadReviewRequests: @Sendable (WorkspaceGitHubRepositoryContext, WorkspaceGitHubReviewFilter) throws -> [WorkspaceGitHubReviewRequestSummary]
+        public var loadPullDetail: @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> WorkspaceGitHubPullDetail
+        public var loadIssueDetail: @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> WorkspaceGitHubIssueDetail
+
+        public init(
+            resolveRepositoryContext: @escaping @Sendable (WorkspaceGitRepositoryContext) throws -> WorkspaceGitHubRepositoryContext,
+            loadAuthStatus: @escaping @Sendable (WorkspaceGitHubRepositoryContext) -> WorkspaceGitHubAuthStatus,
+            loadPulls: @escaping @Sendable (WorkspaceGitHubRepositoryContext, WorkspaceGitHubPullFilter) throws -> [WorkspaceGitHubPullSummary],
+            loadIssues: @escaping @Sendable (WorkspaceGitHubRepositoryContext, WorkspaceGitHubIssueFilter) throws -> [WorkspaceGitHubIssueSummary],
+            loadReviewRequests: @escaping @Sendable (WorkspaceGitHubRepositoryContext, WorkspaceGitHubReviewFilter) throws -> [WorkspaceGitHubReviewRequestSummary],
+            loadPullDetail: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> WorkspaceGitHubPullDetail,
+            loadIssueDetail: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> WorkspaceGitHubIssueDetail
+        ) {
+            self.resolveRepositoryContext = resolveRepositoryContext
+            self.loadAuthStatus = loadAuthStatus
+            self.loadPulls = loadPulls
+            self.loadIssues = loadIssues
+            self.loadReviewRequests = loadReviewRequests
+            self.loadPullDetail = loadPullDetail
+            self.loadIssueDetail = loadIssueDetail
+        }
+
+        public static func live(service: NativeGitHubRepositoryService) -> Client {
+            Client(
+                resolveRepositoryContext: {
+                    try service.resolveRepositoryContext(
+                        rootProjectPath: $0.rootProjectPath,
+                        repositoryPath: $0.repositoryPath
+                    )
+                },
+                loadAuthStatus: { (try? service.checkAuthStatus(host: $0.host)) ?? .unchecked(host: $0.host) },
+                loadPulls: { try service.loadPulls(in: $0, filter: $1) },
+                loadIssues: { try service.loadIssues(in: $0, filter: $1) },
+                loadReviewRequests: { try service.loadReviewRequests(in: $0, filter: $1) },
+                loadPullDetail: { try service.loadPullDetail(in: $0, number: $1) },
+                loadIssueDetail: { try service.loadIssueDetail(in: $0, number: $1) }
+            )
+        }
+    }
+
+    @ObservationIgnored private let client: Client
+    @ObservationIgnored private var refreshTask: Task<Void, Never>?
+    @ObservationIgnored private var refreshRevision = 0
+    @ObservationIgnored private var detailTask: Task<Void, Never>?
+    @ObservationIgnored private var detailRevision = 0
+    @ObservationIgnored private var pullDetailsByNumber: [Int: WorkspaceGitHubPullDetail] = [:]
+    @ObservationIgnored private var issueDetailsByNumber: [Int: WorkspaceGitHubIssueDetail] = [:]
+
+    public var repositoryContext: WorkspaceGitRepositoryContext
+    public private(set) var gitHubContext: WorkspaceGitHubRepositoryContext?
+    public private(set) var authStatus: WorkspaceGitHubAuthStatus
+    public var section: WorkspaceGitHubSection
+    public var pullFilter: WorkspaceGitHubPullFilter
+    public var issueFilter: WorkspaceGitHubIssueFilter
+    public var reviewFilter: WorkspaceGitHubReviewFilter
+    public private(set) var pulls: [WorkspaceGitHubPullSummary]
+    public private(set) var issues: [WorkspaceGitHubIssueSummary]
+    public private(set) var reviewRequests: [WorkspaceGitHubReviewRequestSummary]
+    public private(set) var selectedPullNumber: Int?
+    public private(set) var selectedIssueNumber: Int?
+    public private(set) var selectedPullDetail: WorkspaceGitHubPullDetail?
+    public private(set) var selectedIssueDetail: WorkspaceGitHubIssueDetail?
+    public private(set) var isLoading: Bool
+    public private(set) var isLoadingDetail: Bool
+    public var errorMessage: String?
+    public var detailErrorMessage: String?
+
+    public init(
+        repositoryContext: WorkspaceGitRepositoryContext,
+        section: WorkspaceGitHubSection = .pulls,
+        client: Client
+    ) {
+        self.repositoryContext = repositoryContext
+        self.client = client
+        self.gitHubContext = nil
+        self.authStatus = .unchecked(host: "github.com")
+        self.section = section
+        self.pullFilter = WorkspaceGitHubPullFilter()
+        self.issueFilter = WorkspaceGitHubIssueFilter()
+        self.reviewFilter = WorkspaceGitHubReviewFilter()
+        self.pulls = []
+        self.issues = []
+        self.reviewRequests = []
+        self.selectedPullNumber = nil
+        self.selectedIssueNumber = nil
+        self.selectedPullDetail = nil
+        self.selectedIssueDetail = nil
+        self.isLoading = false
+        self.isLoadingDetail = false
+        self.errorMessage = nil
+        self.detailErrorMessage = nil
+    }
+
+    deinit {
+        refreshTask?.cancel()
+        detailTask?.cancel()
+    }
+
+    public var displayRepositoryTitle: String {
+        gitHubContext?.repositoryFullName ?? repositoryContext.repositoryPath
+    }
+
+    public var hasUsableRepositoryContext: Bool {
+        gitHubContext != nil
+    }
+
+    public var selectedPullSummary: WorkspaceGitHubPullSummary? {
+        pulls.first(where: { $0.number == selectedPullNumber })
+    }
+
+    public var selectedReviewRequestSummary: WorkspaceGitHubReviewRequestSummary? {
+        reviewRequests.first(where: { $0.number == selectedPullNumber })
+    }
+
+    public var selectedIssueSummary: WorkspaceGitHubIssueSummary? {
+        issues.first(where: { $0.number == selectedIssueNumber })
+    }
+
+    public func updateRepositoryContext(_ repositoryContext: WorkspaceGitRepositoryContext) {
+        guard self.repositoryContext != repositoryContext else {
+            return
+        }
+        self.repositoryContext = repositoryContext
+        gitHubContext = nil
+        authStatus = .unchecked(host: "github.com")
+        pulls = []
+        issues = []
+        reviewRequests = []
+        selectedPullNumber = nil
+        selectedIssueNumber = nil
+        selectedPullDetail = nil
+        selectedIssueDetail = nil
+        pullDetailsByNumber.removeAll()
+        issueDetailsByNumber.removeAll()
+        errorMessage = nil
+        detailErrorMessage = nil
+    }
+
+    public func setSection(_ section: WorkspaceGitHubSection) {
+        guard self.section != section else {
+            return
+        }
+        self.section = section
+        detailErrorMessage = nil
+        refreshIfNeeded()
+    }
+
+    public func refreshIfNeeded() {
+        switch section {
+        case .pulls where pulls.isEmpty:
+            refresh()
+        case .issues where issues.isEmpty:
+            refresh()
+        case .reviews where reviewRequests.isEmpty:
+            refresh()
+        default:
+            selectDefaultDetailIfNeeded()
+        }
+    }
+
+    public func refresh() {
+        refreshTask?.cancel()
+        refreshRevision += 1
+        let revision = refreshRevision
+        let repositoryContext = repositoryContext
+        let section = section
+        let pullFilter = self.pullFilter
+        let issueFilter = self.issueFilter
+        let reviewFilter = self.reviewFilter
+        errorMessage = nil
+        isLoading = true
+
+        refreshTask = Task { [client] in
+            do {
+                let payload = try await Task.detached(priority: .userInitiated) {
+                    let gitHubContext = try client.resolveRepositoryContext(repositoryContext)
+                    let authStatus = client.loadAuthStatus(gitHubContext)
+                    guard authStatus.isAuthenticated else {
+                        return RefreshPayload(
+                            gitHubContext: gitHubContext,
+                            authStatus: authStatus,
+                            pulls: [],
+                            issues: [],
+                            reviewRequests: []
+                        )
+                    }
+
+                    let pulls = try client.loadPulls(gitHubContext, pullFilter)
+                    let issues = try client.loadIssues(gitHubContext, issueFilter)
+                    let reviews = try client.loadReviewRequests(gitHubContext, reviewFilter)
+                    return RefreshPayload(
+                        gitHubContext: gitHubContext,
+                        authStatus: authStatus,
+                        pulls: pulls,
+                        issues: issues,
+                        reviewRequests: reviews
+                    )
+                }.value
+
+                guard !Task.isCancelled else {
+                    return
+                }
+                await MainActor.run { [weak self] in
+                    guard let self, self.refreshRevision == revision else {
+                        return
+                    }
+                    self.gitHubContext = payload.gitHubContext
+                    self.authStatus = payload.authStatus
+                    self.pulls = payload.pulls
+                    self.issues = payload.issues
+                    self.reviewRequests = payload.reviewRequests
+                    self.isLoading = false
+                    self.selectDefaultDetailIfNeeded(forceReloadFor: section)
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                await MainActor.run { [weak self] in
+                    guard let self, self.refreshRevision == revision else {
+                        return
+                    }
+                    self.isLoading = false
+                    self.errorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                }
+            }
+        }
+    }
+
+    public func selectPull(number: Int?) {
+        guard selectedPullNumber != number else {
+            return
+        }
+        selectedPullNumber = number
+        selectedPullDetail = nil
+        detailErrorMessage = nil
+        guard let number else {
+            isLoadingDetail = false
+            detailTask?.cancel()
+            return
+        }
+        if let cachedDetail = pullDetailsByNumber[number] {
+            selectedPullDetail = cachedDetail
+            return
+        }
+        loadSelectedPullDetail(number)
+    }
+
+    public func selectIssue(number: Int?) {
+        guard selectedIssueNumber != number else {
+            return
+        }
+        selectedIssueNumber = number
+        selectedIssueDetail = nil
+        detailErrorMessage = nil
+        guard let number else {
+            isLoadingDetail = false
+            detailTask?.cancel()
+            return
+        }
+        if let cachedDetail = issueDetailsByNumber[number] {
+            selectedIssueDetail = cachedDetail
+            return
+        }
+        loadSelectedIssueDetail(number)
+    }
+
+    private func selectDefaultDetailIfNeeded(forceReloadFor section: WorkspaceGitHubSection? = nil) {
+        switch section ?? self.section {
+        case .pulls:
+            let availableNumbers = Set(pulls.map(\.number))
+            let nextNumber = availableNumbers.contains(selectedPullNumber ?? -1) ? selectedPullNumber : pulls.first?.number
+            if selectedPullNumber != nextNumber {
+                selectPull(number: nextNumber)
+            } else if let nextNumber {
+                loadSelectedPullDetail(nextNumber, useCacheIfAvailable: true)
+            }
+        case .reviews:
+            let availableNumbers = Set(reviewRequests.map(\.number))
+            let nextNumber = availableNumbers.contains(selectedPullNumber ?? -1) ? selectedPullNumber : reviewRequests.first?.number
+            if selectedPullNumber != nextNumber {
+                selectPull(number: nextNumber)
+            } else if let nextNumber {
+                loadSelectedPullDetail(nextNumber, useCacheIfAvailable: true)
+            }
+        case .issues:
+            let availableNumbers = Set(issues.map(\.number))
+            let nextNumber = availableNumbers.contains(selectedIssueNumber ?? -1) ? selectedIssueNumber : issues.first?.number
+            if selectedIssueNumber != nextNumber {
+                selectIssue(number: nextNumber)
+            } else if let nextNumber {
+                loadSelectedIssueDetail(nextNumber, useCacheIfAvailable: true)
+            }
+        }
+    }
+
+    private func loadSelectedPullDetail(_ number: Int, useCacheIfAvailable: Bool = false) {
+        guard let gitHubContext else {
+            return
+        }
+        if useCacheIfAvailable, let cachedDetail = pullDetailsByNumber[number] {
+            selectedPullDetail = cachedDetail
+            return
+        }
+
+        detailTask?.cancel()
+        detailRevision += 1
+        let revision = detailRevision
+        isLoadingDetail = true
+
+        detailTask = Task { [client] in
+            do {
+                let detail = try await Task.detached(priority: .userInitiated) {
+                    try client.loadPullDetail(gitHubContext, number)
+                }.value
+                guard !Task.isCancelled else {
+                    return
+                }
+                await MainActor.run { [weak self] in
+                    guard let self, self.detailRevision == revision, self.selectedPullNumber == number else {
+                        return
+                    }
+                    self.pullDetailsByNumber[number] = detail
+                    self.selectedPullDetail = detail
+                    self.isLoadingDetail = false
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                await MainActor.run { [weak self] in
+                    guard let self, self.detailRevision == revision, self.selectedPullNumber == number else {
+                        return
+                    }
+                    self.isLoadingDetail = false
+                    self.detailErrorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private func loadSelectedIssueDetail(_ number: Int, useCacheIfAvailable: Bool = false) {
+        guard let gitHubContext else {
+            return
+        }
+        if useCacheIfAvailable, let cachedDetail = issueDetailsByNumber[number] {
+            selectedIssueDetail = cachedDetail
+            return
+        }
+
+        detailTask?.cancel()
+        detailRevision += 1
+        let revision = detailRevision
+        isLoadingDetail = true
+
+        detailTask = Task { [client] in
+            do {
+                let detail = try await Task.detached(priority: .userInitiated) {
+                    try client.loadIssueDetail(gitHubContext, number)
+                }.value
+                guard !Task.isCancelled else {
+                    return
+                }
+                await MainActor.run { [weak self] in
+                    guard let self, self.detailRevision == revision, self.selectedIssueNumber == number else {
+                        return
+                    }
+                    self.issueDetailsByNumber[number] = detail
+                    self.selectedIssueDetail = detail
+                    self.isLoadingDetail = false
+                }
+            } catch is CancellationError {
+                return
+            } catch {
+                await MainActor.run { [weak self] in
+                    guard let self, self.detailRevision == revision, self.selectedIssueNumber == number else {
+                        return
+                    }
+                    self.isLoadingDetail = false
+                    self.detailErrorMessage = (error as? LocalizedError)?.errorDescription ?? error.localizedDescription
+                }
+            }
+        }
+    }
+
+    private struct RefreshPayload: Sendable {
+        var gitHubContext: WorkspaceGitHubRepositoryContext
+        var authStatus: WorkspaceGitHubAuthStatus
+        var pulls: [WorkspaceGitHubPullSummary]
+        var issues: [WorkspaceGitHubIssueSummary]
+        var reviewRequests: [WorkspaceGitHubReviewRequestSummary]
+    }
+}

--- a/macos/Tests/DevHavenCoreTests/NativeGitHubRepositoryServiceTests.swift
+++ b/macos/Tests/DevHavenCoreTests/NativeGitHubRepositoryServiceTests.swift
@@ -1,0 +1,132 @@
+import XCTest
+@testable import DevHavenCore
+
+final class NativeGitHubRepositoryServiceTests: XCTestCase {
+    func testAddIssueCommentRejectsEmptyBody() throws {
+        let service = makeService { _, _, _, _ in
+            XCTFail("空评论不应触发 gh 命令")
+            return .init(command: [], stdout: "", stderr: "", exitCode: 0)
+        }
+
+        XCTAssertThrowsError(
+            try service.addIssueComment(in: Self.repositoryContext, number: 42, body: "   \n")
+        ) { error in
+            XCTAssertEqual(
+                error as? WorkspaceGitHubCommandError,
+                .operationRejected("评论内容不能为空")
+            )
+        }
+    }
+
+    func testMergePullRunsMergeCommand() throws {
+        let capture = CommandCapture()
+        let service = makeService { arguments, repositoryPath, _, _ in
+            capture.record(arguments: arguments, repositoryPath: repositoryPath)
+            return .init(command: ["/usr/bin/env", "gh"] + arguments, stdout: "", stderr: "", exitCode: 0)
+        }
+
+        try service.mergePull(in: Self.repositoryContext, number: 108)
+
+        XCTAssertEqual(capture.arguments, ["pr", "merge", "108", "-R", "octo/devhaven", "--merge"])
+        XCTAssertEqual(capture.repositoryPath, "/tmp/devhaven-root")
+    }
+
+    func testCheckoutPullBranchUsesExecutionPath() throws {
+        let capture = CommandCapture()
+        let service = makeService { arguments, repositoryPath, _, _ in
+            capture.record(arguments: arguments, repositoryPath: repositoryPath)
+            return .init(command: ["/usr/bin/env", "gh"] + arguments, stdout: "", stderr: "", exitCode: 0)
+        }
+
+        try service.checkoutPullBranch(
+            in: Self.repositoryContext,
+            number: 9,
+            at: "/tmp/devhaven-worktree"
+        )
+
+        XCTAssertEqual(capture.arguments, ["pr", "checkout", "9", "-R", "octo/devhaven"])
+        XCTAssertEqual(capture.repositoryPath, "/tmp/devhaven-worktree")
+    }
+
+    func testSubmitReviewRequestChangesRejectsEmptyBody() throws {
+        let service = makeService { _, _, _, _ in
+            XCTFail("空 review 说明不应触发 gh 命令")
+            return .init(command: [], stdout: "", stderr: "", exitCode: 0)
+        }
+
+        XCTAssertThrowsError(
+            try service.submitReview(
+                in: Self.repositoryContext,
+                number: 13,
+                event: .requestChanges,
+                body: "   "
+            )
+        ) { error in
+            XCTAssertEqual(
+                error as? WorkspaceGitHubCommandError,
+                .operationRejected("请求修改时请填写说明")
+            )
+        }
+    }
+
+    func testSubmitApproveReviewAllowsEmptyBody() throws {
+        let capture = CommandCapture()
+        let service = makeService { arguments, repositoryPath, _, _ in
+            capture.record(arguments: arguments, repositoryPath: repositoryPath)
+            return .init(command: ["/usr/bin/env", "gh"] + arguments, stdout: "", stderr: "", exitCode: 0)
+        }
+
+        try service.submitReview(
+            in: Self.repositoryContext,
+            number: 21,
+            event: .approve,
+            body: nil
+        )
+
+        XCTAssertEqual(capture.arguments, ["pr", "review", "21", "-R", "octo/devhaven", "--approve"])
+        XCTAssertEqual(capture.repositoryPath, "/tmp/devhaven-root")
+    }
+
+    private func makeService(
+        _ executeOverride: @escaping NativeGitHubCommandRunner.Execution
+    ) -> NativeGitHubRepositoryService {
+        NativeGitHubRepositoryService(
+            runner: NativeGitHubCommandRunner(executeOverride: executeOverride)
+        )
+    }
+
+    private static let repositoryContext = WorkspaceGitHubRepositoryContext(
+        rootProjectPath: "/tmp/devhaven-root",
+        repositoryPath: "/tmp/devhaven-root",
+        remoteName: "origin",
+        remoteURL: "git@github.com:octo/devhaven.git",
+        host: "github.com",
+        owner: "octo",
+        name: "devhaven"
+    )
+}
+
+private final class CommandCapture: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storageArguments = [String]()
+    private var storageRepositoryPath = ""
+
+    var arguments: [String] {
+        lock.lock()
+        defer { lock.unlock() }
+        return storageArguments
+    }
+
+    var repositoryPath: String {
+        lock.lock()
+        defer { lock.unlock() }
+        return storageRepositoryPath
+    }
+
+    func record(arguments: [String], repositoryPath: String) {
+        lock.lock()
+        storageArguments = arguments
+        storageRepositoryPath = repositoryPath
+        lock.unlock()
+    }
+}

--- a/macos/Tests/DevHavenCoreTests/WorkspaceGitHubViewModelTests.swift
+++ b/macos/Tests/DevHavenCoreTests/WorkspaceGitHubViewModelTests.swift
@@ -1,0 +1,475 @@
+import Foundation
+import XCTest
+@testable import DevHavenCore
+
+final class WorkspaceGitHubViewModelTests: XCTestCase {
+    @MainActor
+    func testAddCommentToSelectedIssueRefreshesDetailAndClearsDraft() async throws {
+        let now = Date(timeIntervalSince1970: 1_716_000_000)
+        let recorder = GitHubActionRecorder()
+        let issueSummary = Self.makeIssueSummary(number: 56, title: "Fix login bug", commentsCount: 0, updatedAt: now)
+        let refreshedIssueSummary = Self.makeIssueSummary(number: 56, title: "Fix login bug", commentsCount: 1, updatedAt: now.addingTimeInterval(60))
+        let initialIssueDetail = Self.makeIssueDetail(
+            number: 56,
+            title: "Fix login bug",
+            comments: [],
+            updatedAt: now
+        )
+        let refreshedIssueDetail = Self.makeIssueDetail(
+            number: 56,
+            title: "Fix login bug",
+            comments: [
+                WorkspaceGitHubComment(
+                    id: "comment-1",
+                    author: WorkspaceGitHubActor(login: "tester"),
+                    body: "ship it",
+                    createdAt: now.addingTimeInterval(60),
+                    url: "https://example.com/comment-1"
+                )
+            ],
+            updatedAt: now.addingTimeInterval(60)
+        )
+        let issueDetails = LockedState([initialIssueDetail, refreshedIssueDetail])
+        let issueSummaries = LockedState([issueSummary, refreshedIssueSummary])
+
+        let viewModel = WorkspaceGitHubViewModel(
+            repositoryContext: Self.repositoryContext,
+            executionPath: "/tmp/devhaven-worktree",
+            section: .issues,
+            client: Self.makeClient(
+                loadIssues: { _, _ in [issueSummaries.next()] },
+                loadIssueDetail: { _, _ in issueDetails.next() },
+                addIssueComment: { _, number, body in
+                    recorder.issueCommentNumber = number
+                    recorder.issueCommentBody = body
+                }
+            )
+        )
+
+        viewModel.refresh()
+        let didLoadDetail = await waitUntil(timeout: 1) { viewModel.selectedIssueDetail?.number == 56 }
+        XCTAssertTrue(didLoadDetail)
+
+        viewModel.issueCommentDraft = "ship it"
+        viewModel.addCommentToSelectedIssue()
+
+        let didRefreshComment = await waitUntil(timeout: 1) {
+            recorder.issueCommentBody == "ship it"
+                && viewModel.lastSuccessfulMutation == .addIssueComment
+                && viewModel.issueCommentDraft.isEmpty
+                && viewModel.selectedIssueDetail?.commentsCount == 1
+        }
+        XCTAssertTrue(didRefreshComment)
+        XCTAssertEqual(recorder.issueCommentNumber, 56)
+        XCTAssertNil(viewModel.mutationErrorMessage)
+    }
+
+    @MainActor
+    func testCreateAndCheckoutBranchForSelectedIssueUsesExecutionPath() async throws {
+        let issueDetail = Self.makeIssueDetail(number: 56, title: "Fix login bug", comments: [], updatedAt: Self.now)
+        let recorder = GitHubActionRecorder()
+
+        let viewModel = WorkspaceGitHubViewModel(
+            repositoryContext: Self.repositoryContext,
+            executionPath: "/tmp/devhaven-worktree",
+            section: .issues,
+            client: Self.makeClient(
+                loadIssues: { _, _ in [Self.makeIssueSummary(number: 56, title: "Fix login bug", commentsCount: 0, updatedAt: Self.now)] },
+                loadIssueDetail: { _, _ in issueDetail },
+                createLocalBranch: { path, name, startPoint in
+                    recorder.createdBranchPath = path
+                    recorder.createdBranchName = name
+                    recorder.createdBranchStartPoint = startPoint
+                },
+                checkoutLocalBranch: { path, name in
+                    recorder.checkedOutBranchPath = path
+                    recorder.checkedOutBranchName = name
+                }
+            )
+        )
+
+        viewModel.refresh()
+        let didLoadDetail = await waitUntil(timeout: 1) { viewModel.selectedIssueDetail?.number == 56 }
+        XCTAssertTrue(didLoadDetail)
+
+        viewModel.createAndCheckoutBranchForSelectedIssue()
+
+        let didCreateBranch = await waitUntil(timeout: 1) {
+            recorder.createdBranchName == "issue/56-fix-login-bug"
+                && recorder.checkedOutBranchName == "issue/56-fix-login-bug"
+                && viewModel.lastSuccessfulMutation == .createIssueBranch
+        }
+        XCTAssertTrue(didCreateBranch)
+        XCTAssertEqual(recorder.createdBranchPath, "/tmp/devhaven-worktree")
+        XCTAssertEqual(recorder.checkedOutBranchPath, "/tmp/devhaven-worktree")
+        XCTAssertNil(recorder.createdBranchStartPoint)
+    }
+
+    @MainActor
+    func testMergeSelectedPullRefreshesPullDetail() async throws {
+        let recorder = GitHubActionRecorder()
+        let initialSummary = Self.makePullSummary(number: 42, state: .open, updatedAt: Self.now)
+        let refreshedSummary = Self.makePullSummary(number: 42, state: .merged, updatedAt: Self.now.addingTimeInterval(60))
+        let pullSummaries = LockedState([initialSummary, refreshedSummary])
+        let pullDetails = LockedState([
+            Self.makePullDetail(number: 42, state: .open, reviewDecision: .reviewRequired, updatedAt: Self.now),
+            Self.makePullDetail(number: 42, state: .merged, reviewDecision: .approved, updatedAt: Self.now.addingTimeInterval(60)),
+        ])
+
+        let viewModel = WorkspaceGitHubViewModel(
+            repositoryContext: Self.repositoryContext,
+            executionPath: "/tmp/devhaven-root",
+            section: .pulls,
+            client: Self.makeClient(
+                loadPulls: { _, _ in [pullSummaries.next()] },
+                loadPullDetail: { _, _ in pullDetails.next() },
+                mergePull: { _, number, method in
+                    recorder.mergedPullNumber = number
+                    recorder.mergeMethod = method
+                }
+            )
+        )
+
+        viewModel.refresh()
+        let didLoadDetail = await waitUntil(timeout: 1) { viewModel.selectedPullDetail?.number == 42 }
+        XCTAssertTrue(didLoadDetail)
+
+        viewModel.mergeSelectedPull()
+
+        let didMergePull = await waitUntil(timeout: 1) {
+            recorder.mergedPullNumber == 42
+                && recorder.mergeMethod == .merge
+                && viewModel.selectedPullDetail?.state == .merged
+                && viewModel.lastSuccessfulMutation == .mergePull(.merge)
+        }
+        XCTAssertTrue(didMergePull)
+    }
+
+    @MainActor
+    func testSubmitReviewForSelectedPullRefreshesReviewSection() async throws {
+        let recorder = GitHubActionRecorder()
+        let reviews = LockedState([
+            Self.makeReviewSummary(number: 9, state: .open, updatedAt: Self.now),
+            Self.makeReviewSummary(number: 9, state: .open, updatedAt: Self.now.addingTimeInterval(60)),
+        ])
+        let pullDetails = LockedState([
+            Self.makePullDetail(number: 9, state: .open, reviewDecision: .reviewRequired, updatedAt: Self.now),
+            Self.makePullDetail(number: 9, state: .open, reviewDecision: .changesRequested, updatedAt: Self.now.addingTimeInterval(60)),
+        ])
+
+        let viewModel = WorkspaceGitHubViewModel(
+            repositoryContext: Self.repositoryContext,
+            executionPath: "/tmp/devhaven-worktree",
+            section: .reviews,
+            client: Self.makeClient(
+                loadReviewRequests: { _, _ in [reviews.next()] },
+                loadPullDetail: { _, _ in pullDetails.next() },
+                submitReview: { _, number, event, body in
+                    recorder.reviewPullNumber = number
+                    recorder.reviewEvent = event
+                    recorder.reviewBody = body
+                }
+            )
+        )
+
+        viewModel.refresh()
+        let didLoadDetail = await waitUntil(timeout: 1) { viewModel.selectedPullDetail?.number == 9 }
+        XCTAssertTrue(didLoadDetail)
+
+        viewModel.reviewCommentDraft = "please fix the failing test"
+        viewModel.submitReviewForSelectedPull(event: .requestChanges)
+
+        let didSubmitReview = await waitUntil(timeout: 1) {
+            recorder.reviewPullNumber == 9
+                && recorder.reviewEvent == .requestChanges
+                && recorder.reviewBody == "please fix the failing test"
+                && viewModel.reviewCommentDraft.isEmpty
+                && viewModel.selectedPullDetail?.reviewDecision == .changesRequested
+                && viewModel.lastSuccessfulMutation == .submitReview(.requestChanges)
+        }
+        XCTAssertTrue(didSubmitReview)
+    }
+
+    private static func makeClient(
+        loadPulls: @escaping @Sendable (WorkspaceGitHubRepositoryContext, WorkspaceGitHubPullFilter) throws -> [WorkspaceGitHubPullSummary] = { _, _ in [] },
+        loadIssues: @escaping @Sendable (WorkspaceGitHubRepositoryContext, WorkspaceGitHubIssueFilter) throws -> [WorkspaceGitHubIssueSummary] = { _, _ in [] },
+        loadReviewRequests: @escaping @Sendable (WorkspaceGitHubRepositoryContext, WorkspaceGitHubReviewFilter) throws -> [WorkspaceGitHubReviewRequestSummary] = { _, _ in [] },
+        loadPullDetail: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> WorkspaceGitHubPullDetail = { _, number in
+            makePullDetail(number: number, state: .open, reviewDecision: .none, updatedAt: now)
+        },
+        loadIssueDetail: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> WorkspaceGitHubIssueDetail = { _, number in
+            makeIssueDetail(number: number, title: "Issue \(number)", comments: [], updatedAt: now)
+        },
+        addIssueComment: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int, String) throws -> Void = { _, _, _ in },
+        closeIssue: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> Void = { _, _ in },
+        reopenIssue: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> Void = { _, _ in },
+        createLocalBranch: @escaping @Sendable (String, String, String?) throws -> Void = { _, _, _ in },
+        checkoutLocalBranch: @escaping @Sendable (String, String) throws -> Void = { _, _ in },
+        addPullComment: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int, String) throws -> Void = { _, _, _ in },
+        closePull: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> Void = { _, _ in },
+        reopenPull: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int) throws -> Void = { _, _ in },
+        mergePull: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int, WorkspaceGitHubPullMergeMethod) throws -> Void = { _, _, _ in },
+        checkoutPullBranch: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int, String) throws -> Void = { _, _, _ in },
+        submitReview: @escaping @Sendable (WorkspaceGitHubRepositoryContext, Int, WorkspaceGitHubReviewSubmissionEvent, String?) throws -> Void = { _, _, _, _ in }
+    ) -> WorkspaceGitHubViewModel.Client {
+        WorkspaceGitHubViewModel.Client(
+            resolveRepositoryContext: { _ in repositoryGitHubContext },
+            loadAuthStatus: { _ in WorkspaceGitHubAuthStatus(host: "github.com", state: .authenticated, activeLogin: "tester") },
+            loadPulls: loadPulls,
+            loadIssues: loadIssues,
+            loadReviewRequests: loadReviewRequests,
+            loadPullDetail: loadPullDetail,
+            loadIssueDetail: loadIssueDetail,
+            addIssueComment: addIssueComment,
+            closeIssue: closeIssue,
+            reopenIssue: reopenIssue,
+            createLocalBranch: createLocalBranch,
+            checkoutLocalBranch: checkoutLocalBranch,
+            addPullComment: addPullComment,
+            closePull: closePull,
+            reopenPull: reopenPull,
+            mergePull: mergePull,
+            checkoutPullBranch: checkoutPullBranch,
+            submitReview: submitReview
+        )
+    }
+
+    private static func makeIssueSummary(
+        number: Int,
+        title: String,
+        commentsCount: Int,
+        updatedAt: Date
+    ) -> WorkspaceGitHubIssueSummary {
+        WorkspaceGitHubIssueSummary(
+            id: "issue-\(number)",
+            number: number,
+            title: title,
+            state: .open,
+            author: WorkspaceGitHubActor(login: "tester"),
+            commentsCount: commentsCount,
+            createdAt: now,
+            updatedAt: updatedAt,
+            url: "https://example.com/issues/\(number)"
+        )
+    }
+
+    private static func makeIssueDetail(
+        number: Int,
+        title: String,
+        comments: [WorkspaceGitHubComment],
+        updatedAt: Date
+    ) -> WorkspaceGitHubIssueDetail {
+        WorkspaceGitHubIssueDetail(
+            id: "issue-\(number)",
+            number: number,
+            title: title,
+            state: .open,
+            author: WorkspaceGitHubActor(login: "tester"),
+            body: "Issue body",
+            createdAt: now,
+            updatedAt: updatedAt,
+            url: "https://example.com/issues/\(number)",
+            comments: comments
+        )
+    }
+
+    private static func makePullSummary(
+        number: Int,
+        state: WorkspaceGitHubPullState,
+        updatedAt: Date
+    ) -> WorkspaceGitHubPullSummary {
+        WorkspaceGitHubPullSummary(
+            id: "pull-\(number)",
+            number: number,
+            title: "PR \(number)",
+            state: state,
+            isDraft: false,
+            author: WorkspaceGitHubActor(login: "tester"),
+            createdAt: now,
+            updatedAt: updatedAt,
+            url: "https://example.com/pulls/\(number)",
+            headRefName: "feature/\(number)",
+            baseRefName: "main"
+        )
+    }
+
+    private static func makeReviewSummary(
+        number: Int,
+        state: WorkspaceGitHubPullState,
+        updatedAt: Date
+    ) -> WorkspaceGitHubReviewRequestSummary {
+        WorkspaceGitHubReviewRequestSummary(
+            id: "review-\(number)",
+            number: number,
+            title: "Review \(number)",
+            state: state,
+            isDraft: false,
+            author: WorkspaceGitHubActor(login: "reviewer"),
+            createdAt: now,
+            updatedAt: updatedAt,
+            url: "https://example.com/reviews/\(number)"
+        )
+    }
+
+    private static func makePullDetail(
+        number: Int,
+        state: WorkspaceGitHubPullState,
+        reviewDecision: WorkspaceGitHubReviewDecision,
+        updatedAt: Date
+    ) -> WorkspaceGitHubPullDetail {
+        WorkspaceGitHubPullDetail(
+            id: "pull-\(number)",
+            number: number,
+            title: "PR \(number)",
+            state: state,
+            isDraft: false,
+            author: WorkspaceGitHubActor(login: "tester"),
+            reviewDecision: reviewDecision,
+            mergeStateStatus: state == .open ? .clean : .blocked,
+            body: "Pull body",
+            createdAt: now,
+            updatedAt: updatedAt,
+            mergedAt: state == .merged ? updatedAt : nil,
+            mergedBy: state == .merged ? WorkspaceGitHubActor(login: "merger") : nil,
+            url: "https://example.com/pulls/\(number)",
+            headRefName: "feature/\(number)",
+            baseRefName: "main",
+            changedFiles: 3,
+            comments: [],
+            commits: []
+        )
+    }
+
+    @MainActor
+    private func waitUntil(
+        timeout: TimeInterval,
+        condition: @escaping @MainActor () -> Bool
+    ) async -> Bool {
+        let deadline = Date().addingTimeInterval(timeout)
+        while Date() < deadline {
+            if condition() {
+                return true
+            }
+            try? await Task.sleep(nanoseconds: 10_000_000)
+        }
+        return condition()
+    }
+
+    private static let now = Date(timeIntervalSince1970: 1_716_000_000)
+    private static let repositoryContext = WorkspaceGitRepositoryContext(
+        rootProjectPath: "/tmp/devhaven-root",
+        repositoryPath: "/tmp/devhaven-root"
+    )
+    private static let repositoryGitHubContext = WorkspaceGitHubRepositoryContext(
+        rootProjectPath: "/tmp/devhaven-root",
+        repositoryPath: "/tmp/devhaven-root",
+        remoteName: "origin",
+        remoteURL: "git@github.com:octo/devhaven.git",
+        host: "github.com",
+        owner: "octo",
+        name: "devhaven"
+    )
+}
+
+private final class GitHubActionRecorder: @unchecked Sendable {
+    private let lock = NSLock()
+    private var storageIssueCommentBody: String?
+    private var storageIssueCommentNumber: Int?
+    private var storageCreatedBranchPath: String?
+    private var storageCreatedBranchName: String?
+    private var storageCreatedBranchStartPoint: String?
+    private var storageCheckedOutBranchPath: String?
+    private var storageCheckedOutBranchName: String?
+    private var storageMergedPullNumber: Int?
+    private var storageMergeMethod: WorkspaceGitHubPullMergeMethod?
+    private var storageReviewPullNumber: Int?
+    private var storageReviewEvent: WorkspaceGitHubReviewSubmissionEvent?
+    private var storageReviewBody: String?
+
+    var issueCommentBody: String? {
+        get { withLock { storageIssueCommentBody } }
+        set { withLock { storageIssueCommentBody = newValue } }
+    }
+
+    var issueCommentNumber: Int? {
+        get { withLock { storageIssueCommentNumber } }
+        set { withLock { storageIssueCommentNumber = newValue } }
+    }
+
+    var createdBranchPath: String? {
+        get { withLock { storageCreatedBranchPath } }
+        set { withLock { storageCreatedBranchPath = newValue } }
+    }
+
+    var createdBranchName: String? {
+        get { withLock { storageCreatedBranchName } }
+        set { withLock { storageCreatedBranchName = newValue } }
+    }
+
+    var createdBranchStartPoint: String? {
+        get { withLock { storageCreatedBranchStartPoint } }
+        set { withLock { storageCreatedBranchStartPoint = newValue } }
+    }
+
+    var checkedOutBranchPath: String? {
+        get { withLock { storageCheckedOutBranchPath } }
+        set { withLock { storageCheckedOutBranchPath = newValue } }
+    }
+
+    var checkedOutBranchName: String? {
+        get { withLock { storageCheckedOutBranchName } }
+        set { withLock { storageCheckedOutBranchName = newValue } }
+    }
+
+    var mergedPullNumber: Int? {
+        get { withLock { storageMergedPullNumber } }
+        set { withLock { storageMergedPullNumber = newValue } }
+    }
+
+    var mergeMethod: WorkspaceGitHubPullMergeMethod? {
+        get { withLock { storageMergeMethod } }
+        set { withLock { storageMergeMethod = newValue } }
+    }
+
+    var reviewPullNumber: Int? {
+        get { withLock { storageReviewPullNumber } }
+        set { withLock { storageReviewPullNumber = newValue } }
+    }
+
+    var reviewEvent: WorkspaceGitHubReviewSubmissionEvent? {
+        get { withLock { storageReviewEvent } }
+        set { withLock { storageReviewEvent = newValue } }
+    }
+
+    var reviewBody: String? {
+        get { withLock { storageReviewBody } }
+        set { withLock { storageReviewBody = newValue } }
+    }
+
+    private func withLock<T>(_ body: () -> T) -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        return body()
+    }
+}
+
+private final class LockedState<T>: @unchecked Sendable {
+    private let lock = NSLock()
+    private var values: [T]
+
+    init(_ values: [T]) {
+        self.values = values
+    }
+
+    func next() -> T {
+        lock.lock()
+        defer { lock.unlock() }
+        if values.count > 1 {
+            return values.removeFirst()
+        }
+        guard let last = values.last else {
+            fatalError("LockedState 至少需要一个值")
+        }
+        return last
+    }
+}


### PR DESCRIPTION
## Summary
- add a workspace GitHub tool window entry and root routing for Issues, Pull Requests, and Reviews
- add gh-backed GitHub models, filters, remote resolution, repository service, and view model flow in DevHavenCore
- polish issue and pull detail layouts with conversation timeline, markdown rendering, sidebar actions, and list header/filter affordances

## Testing
- added coverage in `macos/Tests/DevHavenCoreTests/NativeGitHubRepositoryServiceTests.swift`
- added coverage in `macos/Tests/DevHavenCoreTests/WorkspaceGitHubViewModelTests.swift`
- not run in this PR handoff
